### PR TITLE
Add web chat interface to Nachos admin UI

### DIFF
--- a/packages/core/admin/frontend/src/App.vue
+++ b/packages/core/admin/frontend/src/App.vue
@@ -106,6 +106,16 @@ onMounted(() => {
             Logs
           </RouterLink>
         </li>
+        <li>
+          <RouterLink
+            to="/chat"
+            class="nav-link"
+            :class="{ active: currentPath === '/chat' }"
+          >
+            <span class="nav-icon">💬</span>
+            Chat
+          </RouterLink>
+        </li>
       </ul>
 
       <div class="sidebar-footer">

--- a/packages/core/admin/frontend/src/pages/ChatPage.vue
+++ b/packages/core/admin/frontend/src/pages/ChatPage.vue
@@ -1,0 +1,534 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, nextTick, computed } from 'vue';
+import MarkdownIt from 'markdown-it';
+
+const md = new MarkdownIt({
+  html: false,
+  linkify: true,
+  breaks: true,
+});
+
+interface Message {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+  timestamp: string;
+}
+
+interface StatusEvent {
+  type: 'thinking' | 'tool' | 'done' | 'error' | 'connected';
+  toolName?: string;
+  error?: string;
+}
+
+const messages = ref<Message[]>([]);
+const inputText = ref('');
+const sessionId = ref<string | null>(null);
+const loading = ref(false);
+const error = ref<string | null>(null);
+const currentStatus = ref<StatusEvent | null>(null);
+const messageContainer = ref<HTMLElement | null>(null);
+
+let eventSource: EventSource | null = null;
+
+const messageCount = computed(() => messages.value.length);
+
+function renderMarkdown(text: string): string {
+  return md.render(text);
+}
+
+async function sendMessage() {
+  if (!inputText.value.trim() || loading.value) return;
+
+  const userMessage = inputText.value.trim();
+  inputText.value = '';
+  loading.value = true;
+  error.value = null;
+
+  // Add user message immediately
+  messages.value.push({
+    id: crypto.randomUUID(),
+    role: 'user',
+    text: userMessage,
+    timestamp: new Date().toISOString(),
+  });
+
+  await nextTick();
+  scrollToBottom();
+
+  try {
+    const res = await fetch('/api/chat/send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: userMessage,
+        sessionId: sessionId.value,
+      }),
+    });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(errText || res.statusText);
+    }
+
+    const data = await res.json();
+    
+    // Update session ID if this is the first message
+    if (!sessionId.value && data.sessionId) {
+      sessionId.value = data.sessionId;
+      // Start SSE stream
+      connectSSE();
+    }
+  } catch (err) {
+    error.value = String(err);
+    loading.value = false;
+  }
+}
+
+function connectSSE() {
+  if (!sessionId.value) return;
+
+  if (eventSource) {
+    eventSource.close();
+  }
+
+  const url = `/api/chat/stream?sessionId=${encodeURIComponent(sessionId.value)}`;
+  eventSource = new EventSource(url);
+
+  eventSource.addEventListener('message', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      
+      if (data.type === 'message') {
+        // Add assistant message
+        messages.value.push({
+          id: crypto.randomUUID(),
+          role: 'assistant',
+          text: data.text,
+          timestamp: data.timestamp,
+        });
+        loading.value = false;
+        currentStatus.value = null;
+        nextTick(() => scrollToBottom());
+      }
+    } catch (err) {
+      console.error('[chat] Error parsing message:', err);
+    }
+  });
+
+  eventSource.addEventListener('status', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      
+      if (data.type === 'connected') {
+        console.log('[chat] Connected to SSE stream');
+      } else if (data.type === 'thinking') {
+        currentStatus.value = { type: 'thinking' };
+      } else if (data.type === 'tool') {
+        currentStatus.value = { type: 'tool', toolName: data.tool };
+      } else if (data.type === 'done') {
+        currentStatus.value = { type: 'done' };
+        setTimeout(() => {
+          currentStatus.value = null;
+        }, 1000);
+      } else if (data.type === 'error') {
+        currentStatus.value = { type: 'error', error: data.error };
+        error.value = data.error;
+        loading.value = false;
+      }
+    } catch (err) {
+      console.error('[chat] Error parsing status:', err);
+    }
+  });
+
+  eventSource.addEventListener('error', (e) => {
+    console.error('[chat] SSE error:', e);
+    error.value = 'Connection lost. Please refresh the page.';
+    loading.value = false;
+  });
+}
+
+async function resetSession() {
+  if (!confirm('Reset the chat session? This will clear all messages.')) return;
+
+  try {
+    if (sessionId.value) {
+      await fetch('/api/chat/reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: sessionId.value }),
+      });
+    }
+
+    if (eventSource) {
+      eventSource.close();
+      eventSource = null;
+    }
+
+    messages.value = [];
+    sessionId.value = null;
+    currentStatus.value = null;
+    loading.value = false;
+    error.value = null;
+  } catch (err) {
+    error.value = String(err);
+  }
+}
+
+function scrollToBottom() {
+  if (messageContainer.value) {
+    messageContainer.value.scrollTop = messageContainer.value.scrollHeight;
+  }
+}
+
+function formatTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    sendMessage();
+  }
+}
+
+onUnmounted(() => {
+  if (eventSource) {
+    eventSource.close();
+  }
+});
+</script>
+
+<template>
+  <div class="page chat-page">
+    <header class="page-header">
+      <div>
+        <h1 class="page-title">Web Chat</h1>
+        <p class="page-sub">
+          {{ sessionId ? `Session: ${sessionId.slice(0, 8)}…` : 'No active session' }}
+          <span v-if="messageCount > 0"> · {{ messageCount }} messages</span>
+        </p>
+      </div>
+      <div class="header-actions">
+        <button 
+          class="btn-ghost" 
+          :disabled="!sessionId || loading" 
+          @click="resetSession"
+        >
+          ⟳ Reset Session
+        </button>
+      </div>
+    </header>
+
+    <div v-if="error" class="alert-error">{{ error }}</div>
+
+    <div class="chat-container">
+      <!-- Messages -->
+      <div ref="messageContainer" class="messages">
+        <div v-if="messages.length === 0" class="empty-state">
+          <p class="empty-icon">💬</p>
+          <p class="empty-text">Send a message to start chatting</p>
+        </div>
+
+        <div
+          v-for="msg in messages"
+          :key="msg.id"
+          class="message"
+          :class="{ 'message-user': msg.role === 'user', 'message-assistant': msg.role === 'assistant' }"
+        >
+          <div class="message-header">
+            <span class="message-role">{{ msg.role === 'user' ? 'You' : 'Assistant' }}</span>
+            <span class="message-time">{{ formatTime(msg.timestamp) }}</span>
+          </div>
+          <div
+            v-if="msg.role === 'assistant'"
+            class="message-content markdown-content"
+            v-html="renderMarkdown(msg.text)"
+          ></div>
+          <div v-else class="message-content">{{ msg.text }}</div>
+        </div>
+
+        <!-- Status indicator -->
+        <div v-if="currentStatus" class="status-indicator">
+          <span v-if="currentStatus.type === 'thinking'" class="status-text">
+            <span class="spinner">⟳</span> Thinking...
+          </span>
+          <span v-else-if="currentStatus.type === 'tool'" class="status-text">
+            <span class="spinner">⚙</span> Using tool{{ currentStatus.toolName ? `: ${currentStatus.toolName}` : '' }}...
+          </span>
+          <span v-else-if="currentStatus.type === 'done'" class="status-text">
+            ✓ Done
+          </span>
+        </div>
+      </div>
+
+      <!-- Input -->
+      <div class="input-container">
+        <textarea
+          v-model="inputText"
+          class="chat-input"
+          placeholder="Type a message... (Enter to send, Shift+Enter for new line)"
+          rows="3"
+          :disabled="loading"
+          @keydown="handleKeydown"
+        ></textarea>
+        <button
+          class="btn-send"
+          :disabled="!inputText.trim() || loading"
+          @click="sendMessage"
+        >
+          {{ loading ? 'Sending...' : 'Send' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chat-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 56px);
+  padding: 28px 32px;
+}
+
+.chat-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.empty-icon {
+  font-size: 48px;
+  margin-bottom: 12px;
+  opacity: 0.5;
+}
+
+.empty-text {
+  font-size: 14px;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 80%;
+  animation: fade-in var(--duration-normal) var(--ease-out);
+}
+
+.message-user {
+  align-self: flex-end;
+}
+
+.message-assistant {
+  align-self: flex-start;
+}
+
+.message-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.message-user .message-header {
+  flex-direction: row-reverse;
+}
+
+.message-role {
+  color: var(--text-muted);
+}
+
+.message-time {
+  color: var(--text-faint);
+  font-weight: 400;
+}
+
+.message-content {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  font-size: 14px;
+  line-height: 1.6;
+  word-wrap: break-word;
+}
+
+.message-user .message-content {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+  color: var(--text-strong);
+}
+
+.markdown-content :deep(p) {
+  margin: 0 0 12px 0;
+}
+
+.markdown-content :deep(p:last-child) {
+  margin-bottom: 0;
+}
+
+.markdown-content :deep(pre) {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  overflow-x: auto;
+  margin: 8px 0;
+}
+
+.markdown-content :deep(code) {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--bg);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.markdown-content :deep(pre code) {
+  background: transparent;
+  padding: 0;
+}
+
+.markdown-content :deep(ul),
+.markdown-content :deep(ol) {
+  margin: 8px 0;
+  padding-left: 24px;
+}
+
+.markdown-content :deep(li) {
+  margin: 4px 0;
+}
+
+.markdown-content :deep(a) {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.markdown-content :deep(a:hover) {
+  color: var(--accent-hover);
+}
+
+.markdown-content :deep(blockquote) {
+  border-left: 3px solid var(--border-strong);
+  padding-left: 12px;
+  margin: 8px 0;
+  color: var(--text-muted);
+}
+
+.status-indicator {
+  align-self: flex-start;
+  padding: 8px 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 13px;
+  color: var(--text-muted);
+  animation: fade-in var(--duration-fast) var(--ease-out);
+}
+
+.status-text {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.spinner {
+  display: inline-block;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.input-container {
+  border-top: 1px solid var(--border);
+  padding: 16px;
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  background: var(--bg);
+}
+
+.chat-input {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 10px 14px;
+  font-size: 14px;
+  line-height: 1.5;
+  resize: none;
+  outline: none;
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
+  font-family: var(--font);
+}
+
+.chat-input:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+.chat-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-send {
+  background: var(--accent);
+  color: var(--accent-foreground);
+  border: 1px solid var(--accent);
+  padding: 10px 24px;
+  border-radius: var(--radius);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
+  white-space: nowrap;
+}
+
+.btn-send:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-send:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+</style>

--- a/packages/core/admin/frontend/src/router/index.ts
+++ b/packages/core/admin/frontend/src/router/index.ts
@@ -6,6 +6,7 @@ import SessionsPage from '../pages/SessionsPage.vue';
 import SkillsPage from '../pages/SkillsPage.vue';
 import ServicesPage from '../pages/ServicesPage.vue';
 import LogsPage from '../pages/LogsPage.vue';
+import ChatPage from '../pages/ChatPage.vue';
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -18,5 +19,6 @@ export const router = createRouter({
     { path: '/skills', component: SkillsPage },
     { path: '/services', component: ServicesPage },
     { path: '/logs', component: LogsPage },
+    { path: '/chat', component: ChatPage },
   ],
 });

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -17,13 +17,18 @@
   "dependencies": {
     "@hono/node-server": "^1.13.0",
     "@iarna/toml": "^2.2.5",
+    "@nachos/bus": "workspace:*",
     "@nachos/config": "workspace:*",
+    "@nachos/types": "workspace:*",
     "better-sqlite3": "^12.6.2",
-    "hono": "^4.6.0"
+    "hono": "^4.6.0",
+    "markdown-it": "^14.1.0",
+    "nats": "^2.29.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/iarna__toml": "^2.0.5",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^22.10.5",
     "@vitejs/plugin-vue": "^5.2.1",
     "tsx": "^4.19.2",

--- a/packages/core/admin/src/routes/chat.ts
+++ b/packages/core/admin/src/routes/chat.ts
@@ -1,0 +1,215 @@
+import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
+import { connect, type NatsConnection } from 'nats';
+import { TOPICS } from '@nachos/bus';
+import type { 
+  ChannelInboundMessageType as ChannelInboundMessage,
+  ChannelOutboundMessageType as ChannelOutboundMessage 
+} from '@nachos/types';
+import { randomUUID } from 'node:crypto';
+
+const NATS_URL = process.env['NATS_URL'] ?? 'nats://localhost:4222';
+const CHANNEL_ID = 'web';
+
+export const chatRouter = new Hono();
+
+// Get or create NATS connection
+let natsConnection: NatsConnection | null = null;
+
+async function getNatsConnection(): Promise<NatsConnection> {
+  if (!natsConnection || natsConnection.isClosed()) {
+    natsConnection = await connect({ servers: NATS_URL });
+  }
+  return natsConnection;
+}
+
+// Session store (in-memory for now, could be moved to DB)
+const sessions = new Map<string, { sessionId: string; userId: string; conversationId: string }>();
+
+// POST /api/chat/send
+chatRouter.post('/send', async (c) => {
+  try {
+    const body = await c.req.json<{ message: string; sessionId?: string }>();
+    const { message, sessionId: clientSessionId } = body;
+
+    if (!message || typeof message !== 'string') {
+      return c.json({ error: 'Message is required' }, 400);
+    }
+
+    const nc = await getNatsConnection();
+
+    // Get or create session
+    let session = clientSessionId ? sessions.get(clientSessionId) : null;
+    if (!session) {
+      const newSessionId = randomUUID();
+      session = {
+        sessionId: newSessionId,
+        userId: `web-user-${newSessionId.slice(0, 8)}`,
+        conversationId: newSessionId,
+      };
+      sessions.set(newSessionId, session);
+    }
+
+    // Publish message to gateway via NATS
+    const inboundMsg: ChannelInboundMessage = {
+      channel: CHANNEL_ID,
+      channelMessageId: randomUUID(),
+      sessionId: session.sessionId,
+      sender: {
+        id: session.userId,
+        name: 'Web User',
+        isAllowed: true,
+      },
+      conversation: {
+        id: session.conversationId,
+        type: 'dm' as const,
+      },
+      content: {
+        text: message,
+      },
+      metadata: {},
+    };
+
+    const topic = TOPICS.channel.inbound(CHANNEL_ID);
+    nc.publish(topic, JSON.stringify(inboundMsg));
+
+    return c.json({
+      ok: true,
+      sessionId: session.sessionId,
+      messageId: randomUUID(),
+    });
+  } catch (err) {
+    console.error('[chat] Send error:', err);
+    return c.json({ error: 'Failed to send message', details: String(err) }, 500);
+  }
+});
+
+// POST /api/chat/reset
+chatRouter.post('/reset', async (c) => {
+  try {
+    const body = await c.req.json<{ sessionId?: string }>();
+    const { sessionId } = body;
+
+    if (sessionId) {
+      sessions.delete(sessionId);
+    }
+
+    return c.json({ ok: true });
+  } catch (err) {
+    return c.json({ error: 'Failed to reset session', details: String(err) }, 500);
+  }
+});
+
+// GET /api/chat/stream (SSE)
+chatRouter.get('/stream', async (c) => {
+  const sessionId = c.req.query('sessionId');
+
+  if (!sessionId) {
+    return c.json({ error: 'sessionId query parameter required' }, 400);
+  }
+
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return c.json({ error: 'Session not found' }, 404);
+  }
+
+  return streamSSE(c, async (stream) => {
+    try {
+      const nc = await getNatsConnection();
+
+      // Subscribe to outbound messages for this channel
+      const outboundTopic = TOPICS.channel.outbound(CHANNEL_ID);
+      const outboundSub = nc.subscribe(outboundTopic);
+
+      // Subscribe to status topics for this session
+      const statusTopics = [
+        TOPICS.status.thinking(session.sessionId),
+        TOPICS.status.tool(session.sessionId),
+        TOPICS.status.done(session.sessionId),
+        TOPICS.status.error(session.sessionId),
+      ];
+
+      const statusSubs = await Promise.all(
+        statusTopics.map((topic) => nc.subscribe(topic))
+      );
+
+      // Send initial connection event
+      await stream.writeSSE({
+        data: JSON.stringify({ type: 'connected', sessionId }),
+        event: 'status',
+      });
+
+      // Process outbound messages
+      (async () => {
+        for await (const msg of outboundSub) {
+          try {
+            const outbound: ChannelOutboundMessage = JSON.parse(msg.string());
+            if (outbound.conversationId === session.conversationId) {
+              await stream.writeSSE({
+                data: JSON.stringify({
+                  type: 'message',
+                  text: outbound.content.text,
+                  timestamp: new Date().toISOString(),
+                }),
+                event: 'message',
+              });
+            }
+          } catch (err) {
+            console.error('[chat] Error processing outbound message:', err);
+          }
+        }
+      })();
+
+      // Process status updates
+      for (const statusSub of statusSubs) {
+        (async () => {
+          for await (const msg of statusSub) {
+            try {
+              const data = JSON.parse(msg.string());
+              const topic = msg.subject;
+
+              let type: string;
+              if (topic.includes('.thinking')) type = 'thinking';
+              else if (topic.includes('.tool')) type = 'tool';
+              else if (topic.includes('.done')) type = 'done';
+              else if (topic.includes('.error')) type = 'error';
+              else continue;
+
+              await stream.writeSSE({
+                data: JSON.stringify({ type, ...data }),
+                event: 'status',
+              });
+            } catch (err) {
+              console.error('[chat] Error processing status message:', err);
+            }
+          }
+        })();
+      }
+
+      // Keep connection alive
+      const keepAlive = setInterval(async () => {
+        try {
+          await stream.writeSSE({
+            data: JSON.stringify({ type: 'ping' }),
+            event: 'ping',
+          });
+        } catch (err) {
+          clearInterval(keepAlive);
+        }
+      }, 30000);
+
+      // Wait for client disconnect
+      await stream.onAbort(() => {
+        clearInterval(keepAlive);
+        outboundSub.unsubscribe();
+        statusSubs.forEach((sub) => sub.unsubscribe());
+      });
+    } catch (err) {
+      console.error('[chat] SSE stream error:', err);
+      await stream.writeSSE({
+        data: JSON.stringify({ type: 'error', error: String(err) }),
+        event: 'error',
+      });
+    }
+  });
+});

--- a/packages/core/admin/src/server.ts
+++ b/packages/core/admin/src/server.ts
@@ -11,6 +11,7 @@ import { sessionsRouter } from './routes/sessions.js';
 import { skillsRouter } from './routes/skills.js';
 import { servicesRouter } from './routes/services.js';
 import { logsRouter } from './routes/logs.js';
+import { chatRouter } from './routes/chat.js';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -49,6 +50,7 @@ app.route('/api/sessions', sessionsRouter);
 app.route('/api/skills', skillsRouter);
 app.route('/api/services', servicesRouter);
 app.route('/api/logs', logsRouter);
+app.route('/api/chat', chatRouter);
 
 app.get('/api/health', (c) =>
   c.json({ status: 'ok', service: 'nachos-admin', timestamp: new Date().toISOString() })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,15 +236,27 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@nachos/bus':
+        specifier: workspace:*
+        version: link:../bus
       '@nachos/config':
         specifier: workspace:*
         version: link:../../shared/config
+      '@nachos/types':
+        specifier: workspace:*
+        version: link:../../shared/types
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
       hono:
         specifier: ^4.6.0
         version: 4.11.9
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.1
+      nats:
+        specifier: ^2.29.3
+        version: 2.29.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -252,6 +264,9 @@ importers:
       '@types/iarna__toml':
         specifier: ^2.0.5
         version: 2.0.5
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.7
@@ -1801,6 +1816,15 @@ packages:
   '@types/jsonwebtoken@8.5.9':
     resolution: {integrity: sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
@@ -2470,6 +2494,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -3205,6 +3233,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3268,6 +3299,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -3275,6 +3310,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -3741,6 +3779,10 @@ packages:
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4238,6 +4280,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -5584,6 +5629,15 @@ snapshots:
     dependencies:
       '@types/node': 22.19.7
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/mime@1.3.5': {}
 
   '@types/mozilla__readability@0.4.2': {}
@@ -6355,6 +6409,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -7292,6 +7348,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -7341,11 +7401,22 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
 
   math-intrinsics@1.1.0: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
 
@@ -7790,6 +7861,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -8434,6 +8507,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
- Created ChatPage.vue with real-time chat interface
  - Markdown rendering for assistant messages
  - Status indicators (thinking, tool execution, done)
  - User/assistant message bubbles
  - Session management with reset functionality

- Added backend chat API routes (/api/chat)
  - POST /api/chat/send - Send messages to gateway via NATS
  - GET /api/chat/stream - SSE stream for real-time updates
  - POST /api/chat/reset - Reset chat session

- Integrated with NATS bus architecture
  - Uses 'web' channel ID
  - Subscribes to channel.outbound and status.* topics
  - Publishes to channel.inbound topic

- Updated navigation with Chat link
- Added markdown-it dependency for rendering
- Added NATS client for backend messaging