### PR TITLE
fix: Add Docker CLI to admin container for services/logs pages

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -228,6 +228,8 @@ services:
     build:
       context: .
       dockerfile: packages/core/admin/Dockerfile
+      args:
+        DOCKER_GID: ${DOCKER_GID:-999}
     image: nachos-admin:dev
     restart: unless-stopped
     depends_on:
@@ -249,6 +251,7 @@ services:
     volumes:
       - ./nachos.toml:/app/nachos.toml:rw
       - ./data/gateway:/app/state:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     develop:
       watch:
         - action: rebuild

--- a/packages/core/admin/Dockerfile
+++ b/packages/core/admin/Dockerfile
@@ -36,9 +36,14 @@ RUN pnpm build:backend
 # ─── Stage 3: Runtime ────────────────────────────────────────────────────────
 FROM node:22-alpine AS runtime
 
-# Create non-root user first
+# Install Docker CLI for container management (services + logs pages)
+RUN apk add --no-cache docker-cli
+
+# Create non-root user and add to docker group for socket access
+# Docker socket GID varies by host — use DOCKER_GID build arg (default 999)
+ARG DOCKER_GID=999
 RUN addgroup -g 1001 nachos && adduser -D -u 1001 -G nachos nachos \
- && (addgroup -g 999 docker 2>/dev/null || true) \
+ && (addgroup -g ${DOCKER_GID} docker 2>/dev/null || true) \
  && (adduser nachos docker 2>/dev/null || true)
 
 WORKDIR /app


### PR DESCRIPTION
Adds Docker CLI and socket access to the admin container so the Services and Logs pages work.

- Installs `docker-cli` Alpine package in runtime stage
- Adds `DOCKER_GID` build arg (default 999) for matching host Docker socket GID
- Mounts `/var/run/docker.sock` read-only into admin container
- Adds `DOCKER_GID` to compose build args with env var override

**Note:** `.env` should set `DOCKER_GID` to match the host's Docker socket group (e.g., 281 on Unraid). The host-paths override also mounts the socket.

**Tested:** Services API returns all 12 nachos containers with state/health. Logs API streams gateway logs via SSE.