### PR TITLE
fix: Add Bedrock provider support and fix Dockerfile builds

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -204,6 +204,11 @@ services:
       PORT: "3001"
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      # AWS Bedrock credentials (uses host env if not set in .env)
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
+      AWS_REGION: ${AWS_REGION:-us-east-1}
       NACHOS_CONFIG: /app/nachos.toml
     volumes:
       - ./nachos.toml:/app/nachos.toml:ro
@@ -237,6 +242,7 @@ services:
         condition: service_healthy
     networks:
       - nachos-internal
+      - nachos-egress
     ports:
       - "8082:8082"
     environment:

--- a/packages/core/admin/Dockerfile
+++ b/packages/core/admin/Dockerfile
@@ -28,7 +28,10 @@ COPY packages/shared/ ./packages/shared/
 COPY packages/core/bus/ ./packages/core/bus/
 COPY packages/core/admin/ ./packages/core/admin/
 
-RUN pnpm install --frozen-lockfile --filter @nachos/admin...
+# Build workspace dependencies first
+RUN pnpm install --frozen-lockfile --filter @nachos/admin... \
+ && pnpm --filter @nachos/types build \
+ && pnpm --filter @nachos/bus build
 
 WORKDIR /build/packages/core/admin
 RUN pnpm build:backend

--- a/packages/core/gateway/Dockerfile
+++ b/packages/core/gateway/Dockerfile
@@ -87,6 +87,12 @@ COPY --chown=nachos:nachos . .
 # Copy prebuilt config dist from shared builder
 COPY --from=config --chown=nachos:nachos /app/packages/shared/config/dist ./packages/shared/config/dist
 
+# Build all workspace dependencies
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/context-manager build && \
+    pnpm --filter @nachos/bus build
+
 # Expose port (gateway will listen on this)
 EXPOSE 3000
 

--- a/packages/core/llm-proxy/src/adapters/registry.ts
+++ b/packages/core/llm-proxy/src/adapters/registry.ts
@@ -16,8 +16,8 @@ export function createAdapterRegistry(config: LLMConfig): AdapterRegistry {
   adapters.set('openai', new OpenAIAdapter());
   adapters.set('ollama', new OllamaAdapter(config.base_url));
   
-  // Bedrock adapter uses AWS credentials from environment or AWS config
-  const awsRegion = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1';
+  // Bedrock adapter uses region from config, then falls back to environment variables
+  const awsRegion = config.region || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1';
   adapters.set('bedrock', createBedrockAdapter(awsRegion));
 
   return {

--- a/packages/shared/config/src/schema.ts
+++ b/packages/shared/config/src/schema.ts
@@ -57,6 +57,7 @@ export interface LLMConfig {
   max_tokens?: number;
   temperature?: number;
   base_url?: string; // For Ollama and custom providers
+  region?: string; // AWS region for Bedrock provider
 }
 
 /**

--- a/packages/shared/config/src/validation.ts
+++ b/packages/shared/config/src/validation.ts
@@ -35,6 +35,7 @@ const CONFIG_SHAPE: SchemaNode = {
     max_tokens: true,
     temperature: true,
     base_url: true,
+    region: true, // AWS region for Bedrock provider
   },
   channels: {
     webchat: { enabled: true, port: true },
@@ -478,11 +479,16 @@ function validateLLMConfig(config: NachosConfig, errors: string[], warnings: str
     return;
   }
 
-  const validProviders = ['anthropic', 'openai', 'ollama', 'custom'];
+  const validProviders = ['anthropic', 'openai', 'ollama', 'bedrock', 'custom'];
   if (!validProviders.includes(config.llm.provider)) {
     errors.push(
       `Invalid llm.provider: "${config.llm.provider}". Must be one of: ${validProviders.join(', ')}`
     );
+  }
+
+  // Bedrock provider should have region specified
+  if (config.llm.provider === 'bedrock' && !config.llm.region) {
+    errors.push('llm.region is required when using bedrock provider');
   }
 
   if (!config.llm.model || config.llm.model.trim() === '') {

--- a/packages/tools/code-runner/Dockerfile
+++ b/packages/tools/code-runner/Dockerfile
@@ -26,10 +26,13 @@ COPY --chown=coderunner:coderunner packages/tools/code-runner ./packages/tools/c
 RUN pnpm install --frozen-lockfile
 
 # Provide minimal root tsconfig
-RUN echo '{"extends":"./tsconfig.base.json","compilerOptions":{"composite":true},"files":[],"references":[{"path":"./packages/shared/types"},{"path":"./packages/shared/utils"}]}' > tsconfig.json
+RUN echo '{"extends":"./tsconfig.base.json","compilerOptions":{"composite":true},"files":[],"references":[{"path":"./packages/shared/types"},{"path":"./packages/shared/utils"},{"path":"./packages/shared/tool-base"}]}' > tsconfig.json
 
-# Build
-RUN pnpm --filter @nachos/tool-code-runner build
+# Build dependencies first, then the tool
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/tool-base build && \
+    pnpm --filter @nachos/tool-code-runner build
 
 ENV NODE_ENV=production
 

--- a/packages/tools/filesystem/Dockerfile
+++ b/packages/tools/filesystem/Dockerfile
@@ -21,10 +21,13 @@ COPY packages/tools/filesystem ./packages/tools/filesystem
 RUN pnpm install --frozen-lockfile
 
 # Provide minimal root tsconfig (avoids references to packages not in this image)
-RUN echo '{"extends":"./tsconfig.base.json","compilerOptions":{"composite":true},"files":[],"references":[{"path":"./packages/shared/types"},{"path":"./packages/shared/utils"}]}' > tsconfig.json
+RUN echo '{"extends":"./tsconfig.base.json","compilerOptions":{"composite":true},"files":[],"references":[{"path":"./packages/shared/types"},{"path":"./packages/shared/utils"},{"path":"./packages/shared/tool-base"}]}' > tsconfig.json
 
-# Build
-RUN pnpm --filter @nachos/tool-filesystem build
+# Build dependencies first, then the tool
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/tool-base build && \
+    pnpm --filter @nachos/tool-filesystem build
 
 # Create non-root user (1001 to avoid conflict with node:alpine built-in 'node' user at 1000)
 RUN addgroup -g 1001 nachos && \

--- a/packages/tools/web-fetch/Dockerfile
+++ b/packages/tools/web-fetch/Dockerfile
@@ -20,10 +20,13 @@ COPY packages/tools/web-fetch ./packages/tools/web-fetch
 RUN pnpm install --frozen-lockfile
 
 # Provide minimal root tsconfig
-RUN echo '{"extends":"./tsconfig.base.json","compilerOptions":{"composite":true},"files":[],"references":[{"path":"./packages/shared/types"},{"path":"./packages/shared/utils"}]}' > tsconfig.json
+RUN echo '{"extends":"./tsconfig.base.json","compilerOptions":{"composite":true},"files":[],"references":[{"path":"./packages/shared/types"},{"path":"./packages/shared/utils"},{"path":"./packages/shared/tool-base"}]}' > tsconfig.json
 
-# Build
-RUN pnpm --filter @nachos/tool-web-fetch build
+# Build dependencies first, then the tool
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/tool-base build && \
+    pnpm --filter @nachos/tool-web-fetch build
 
 # Create non-root user
 RUN addgroup -g 1001 nachos && \


### PR DESCRIPTION
  - Add 'bedrock' as valid LLM provider with 'region' config key
  - Fix tool Dockerfiles to build workspace deps before tool package
  - Fix admin/gateway Dockerfiles for missing dependency builds
  - Add egress network to admin for port exposure