### PR TITLE
feat: add hook failure observability (T-021)

### DIFF
--- a/packages/core/gateway/src/gateway.ts
+++ b/packages/core/gateway/src/gateway.ts
@@ -2797,6 +2797,7 @@ export class Gateway {
         }
       },
       checkBus: () => this.isConnected,
+      getHookStats: () => this.hooks.getStats(),
     });
 
     // Add Cheese statistics if available

--- a/packages/core/gateway/src/health.test.ts
+++ b/packages/core/gateway/src/health.test.ts
@@ -6,6 +6,7 @@ import {
   resetStartTime,
   type HealthCheckDeps,
 } from './health.js';
+import type { HookStats } from './hooks/index.js';
 
 describe('Health Check', () => {
   beforeEach(() => {
@@ -75,6 +76,50 @@ describe('Health Check', () => {
 
       expect(health.status).toBe('unhealthy');
       expect(health.checks.database).toBe('error');
+    });
+
+    it('should return hooks ok when hook stats have no failures', () => {
+      const hookStats: HookStats = {
+        events: { 'message:received': { successCount: 5, failureCount: 0, timeoutCount: 0 } },
+        totalEmits: 5,
+        totalFailures: 0,
+      };
+
+      const health = performHealthCheck({
+        checkDatabase: () => true,
+        checkBus: () => true,
+        getHookStats: () => hookStats,
+      });
+
+      expect(health.status).toBe('healthy');
+      expect(health.checks['hooks']).toBe('ok');
+      expect(health.hookStats).toEqual(hookStats);
+    });
+
+    it('should return hooks error without affecting overall status when hook stats have failures', () => {
+      const hookStats: HookStats = {
+        events: {
+          'message:received': {
+            successCount: 3,
+            failureCount: 2,
+            timeoutCount: 1,
+            lastFailure: { error: 'boom', label: 'test', timestamp: new Date().toISOString() },
+          },
+        },
+        totalEmits: 5,
+        totalFailures: 2,
+      };
+
+      const health = performHealthCheck({
+        checkDatabase: () => true,
+        checkBus: () => true,
+        getHookStats: () => hookStats,
+      });
+
+      // Hook failures should NOT make the gateway unhealthy — they are observability only
+      expect(health.status).toBe('healthy');
+      expect(health.checks['hooks']).toBe('error');
+      expect(health.hookStats).toEqual(hookStats);
     });
   });
 

--- a/packages/core/gateway/src/health.ts
+++ b/packages/core/gateway/src/health.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 import { createLogger } from '@nachos/types';
 import type { HealthCheck, HealthStatus } from '@nachos/types';
 import type { ChannelRegistry, ChannelPresence } from './channel-registry.js';
+import type { HookStats } from './hooks/index.js';
 
 const logger = createLogger('health');
 
@@ -40,6 +41,7 @@ export interface HealthCheckDeps {
   checkDatabase?: () => boolean;
   checkBus?: () => boolean;
   channelRegistry?: ChannelRegistry;
+  getHookStats?: () => HookStats;
 }
 
 /**
@@ -73,7 +75,7 @@ export function resetStartTime(): void {
 /**
  * Perform health checks and return status
  */
-export function performHealthCheck(deps?: HealthCheckDeps): HealthCheck {
+export function performHealthCheck(deps?: HealthCheckDeps): HealthCheck & { hookStats?: HookStats } {
   const checks: Record<string, 'ok' | 'error'> = {};
   let overallStatus: HealthStatus = 'healthy';
 
@@ -115,13 +117,30 @@ export function performHealthCheck(deps?: HealthCheckDeps): HealthCheck {
     overallStatus = 'unhealthy';
   }
 
-  return {
+  // Check hooks (observability only — failures do NOT affect overall liveness/health status)
+  let hookStats: HookStats | undefined;
+  if (deps?.getHookStats) {
+    try {
+      hookStats = deps.getHookStats();
+      checks['hooks'] = hookStats.totalFailures === 0 ? 'ok' : 'error';
+    } catch {
+      checks['hooks'] = 'error';
+    }
+  }
+
+  const result: HealthCheck & { hookStats?: HookStats } = {
     status: overallStatus,
     component: 'gateway',
     version: VERSION,
     uptime: getUptime(),
     checks,
   };
+
+  if (hookStats) {
+    result.hookStats = hookStats;
+  }
+
+  return result;
 }
 
 /**

--- a/packages/core/gateway/src/hooks/hook-registry.test.ts
+++ b/packages/core/gateway/src/hooks/hook-registry.test.ts
@@ -5,17 +5,20 @@ import type {
   MutableBeforeResponseSentPayload,
 } from './hook-types.js';
 
-// Suppress logger output during tests
+// Shared mock logger so we can spy on calls — vi.hoisted ensures it's
+// available when vi.mock's factory runs (which is hoisted to the top).
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+}));
+
 vi.mock('@nachos/types', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    fatal: vi.fn(),
-    trace: vi.fn(),
-    child: vi.fn().mockReturnThis(),
-  }),
+  createLogger: () => mockLogger,
 }));
 
 describe('HookRegistry', () => {
@@ -23,6 +26,7 @@ describe('HookRegistry', () => {
 
   beforeEach(() => {
     hooks = new HookRegistry();
+    vi.clearAllMocks();
   });
 
   // ---------------------------------------------------------------------------
@@ -568,6 +572,168 @@ describe('HookRegistry', () => {
 
       expect(observeHandler).toHaveBeenCalledOnce(); // still only 1
       expect(mutableHandler).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Hook stats / failure observability
+  // ---------------------------------------------------------------------------
+
+  describe('hook stats', () => {
+    function makeMessagePayload() {
+      return {
+        envelopeId: 'env-1',
+        channel: 'slack',
+        channelMessageId: 'msg-1',
+        sender: { id: 'user-1', isAllowed: true },
+        conversation: { id: 'conv-1', type: 'dm' as const },
+        text: 'hello',
+        sessionId: 'sess-1',
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    it('should return zero counts initially', () => {
+      const stats = hooks.getStats();
+      expect(stats.totalEmits).toBe(0);
+      expect(stats.totalFailures).toBe(0);
+      expect(Object.keys(stats.events)).toHaveLength(0);
+    });
+
+    it('should increment successCount on successful emit', async () => {
+      hooks.register('message:received', async () => {});
+      await hooks.emit('message:received', makeMessagePayload());
+
+      const stats = hooks.getStats();
+      expect(stats.events['message:received'].successCount).toBe(1);
+      expect(stats.events['message:received'].failureCount).toBe(0);
+      expect(stats.totalEmits).toBe(1);
+      expect(stats.totalFailures).toBe(0);
+    });
+
+    it('should increment failureCount and record lastFailure on error', async () => {
+      hooks.register('message:received', async () => {
+        throw new Error('handler-error');
+      }, { label: 'bad-handler' });
+
+      await hooks.emit('message:received', makeMessagePayload());
+
+      const stats = hooks.getStats();
+      expect(stats.events['message:received'].failureCount).toBe(1);
+      expect(stats.events['message:received'].lastFailure).toBeDefined();
+      expect(stats.events['message:received'].lastFailure!.error).toBe('handler-error');
+      expect(stats.events['message:received'].lastFailure!.label).toBe('bad-handler');
+      expect(stats.totalFailures).toBe(1);
+    });
+
+    it('should increment timeoutCount for timeout errors', async () => {
+      const shortHooks = new HookRegistry({ handlerTimeoutMs: 10 });
+      shortHooks.register('gateway:startup', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }, { label: 'slow' });
+
+      await shortHooks.emit('gateway:startup', {
+        instanceId: 'gw-1',
+        channels: ['slack'],
+        securityMode: 'standard',
+        streamingEnabled: false,
+        timestamp: new Date().toISOString(),
+      });
+
+      const stats = shortHooks.getStats();
+      expect(stats.events['gateway:startup'].timeoutCount).toBe(1);
+      expect(stats.events['gateway:startup'].failureCount).toBe(1);
+    });
+
+    it('should track per-event stats independently', async () => {
+      hooks.register('message:received', async () => {});
+      hooks.register('session:created', async () => {
+        throw new Error('fail');
+      });
+
+      await hooks.emit('message:received', makeMessagePayload());
+      await hooks.emit('session:created', {
+        session: { id: 's1', channel: 'slack', conversationId: 'c1', userId: 'u1', status: 'active', createdAt: new Date().toISOString() },
+        timestamp: new Date().toISOString(),
+      });
+
+      const stats = hooks.getStats();
+      expect(stats.events['message:received'].successCount).toBe(1);
+      expect(stats.events['message:received'].failureCount).toBe(0);
+      expect(stats.events['session:created'].successCount).toBe(0);
+      expect(stats.events['session:created'].failureCount).toBe(1);
+      expect(stats.totalEmits).toBe(2);
+      expect(stats.totalFailures).toBe(1);
+    });
+
+    it('should clear everything on resetStats()', async () => {
+      hooks.register('message:received', async () => {});
+      await hooks.emit('message:received', makeMessagePayload());
+
+      hooks.resetStats();
+
+      const stats = hooks.getStats();
+      expect(stats.totalEmits).toBe(0);
+      expect(stats.totalFailures).toBe(0);
+      expect(Object.keys(stats.events)).toHaveLength(0);
+    });
+
+    it('should log at warn level for critical hook failures', async () => {
+      hooks.register('session:created', async () => {
+        throw new Error('critical-fail');
+      }, { label: 'my-handler' });
+
+      await hooks.emit('session:created', {
+        session: { id: 's1', channel: 'slack', conversationId: 'c1', userId: 'u1', status: 'active', createdAt: new Date().toISOString() },
+        timestamp: new Date().toISOString(),
+      });
+
+      // Should have been called with critical: true
+      const warnCalls = mockLogger.warn.mock.calls;
+      const criticalCall = warnCalls.find(
+        (call: unknown[]) => call[0] && typeof call[0] === 'object' && (call[0] as Record<string, unknown>).critical === true
+      );
+      expect(criticalCall).toBeDefined();
+      expect(criticalCall![0].event).toBe('session:created');
+    });
+
+    it('should fire repeated failure alert at threshold', async () => {
+      const alertHooks = new HookRegistry({ failureAlertThreshold: 3 });
+      alertHooks.register('message:received', async () => {
+        throw new Error('repeated');
+      });
+
+      // Emit 3 times to cross threshold
+      for (let i = 0; i < 3; i++) {
+        await alertHooks.emit('message:received', makeMessagePayload());
+      }
+
+      const alertCalls = mockLogger.warn.mock.calls.filter(
+        (call: unknown[]) => call[0] && typeof call[0] === 'object' && (call[0] as Record<string, unknown>).hookAlert === true
+      );
+      expect(alertCalls.length).toBeGreaterThanOrEqual(1);
+      expect(alertCalls[0][0].failureCount).toBe(3);
+    });
+
+    it('should track stats for mutable hooks too', async () => {
+      hooks.registerMutable('response:before-send', async () => {
+        throw new Error('mutable-fail');
+      }, { label: 'mutable-bad' });
+
+      await hooks.emitMutable('response:before-send', {
+        sessionId: 'sess-1',
+        channel: 'slack',
+        conversationId: 'conv-1',
+        text: 'hello',
+        format: 'plain',
+        replyToMessageId: undefined,
+        timestamp: new Date().toISOString(),
+      });
+
+      const stats = hooks.getStats();
+      expect(stats.events['response:before-send'].failureCount).toBe(1);
+      expect(stats.events['response:before-send'].lastFailure!.error).toBe('mutable-fail');
+      expect(stats.totalFailures).toBe(1);
     });
   });
 });

--- a/packages/core/gateway/src/hooks/hook-registry.ts
+++ b/packages/core/gateway/src/hooks/hook-registry.ts
@@ -16,9 +16,11 @@
 import { createLogger } from '@nachos/types';
 import type {
   HookEvent,
+  HookEventStats,
   HookHandler,
   HookPayloadMap,
   HookRegistration,
+  HookStats,
   MutableHookEvent,
   MutableHookHandler,
   MutableHookPayloadMap,
@@ -33,6 +35,21 @@ const DEFAULT_PRIORITY = 100;
 /** Default per-handler timeout in milliseconds */
 const DEFAULT_HANDLER_TIMEOUT_MS = 5000;
 
+/** Default failure count before a summary alert is logged */
+const DEFAULT_FAILURE_ALERT_THRESHOLD = 5;
+
+/**
+ * Hook events considered critical for gateway operation.
+ * Failures on these hooks generate an additional structured warn log
+ * with `critical: true` to simplify alerting.
+ */
+const CRITICAL_HOOKS: Set<string> = new Set([
+  'session:created',
+  'message:received',
+  'gateway:startup',
+  'gateway:shutdown',
+]);
+
 /**
  * Options for configuring a HookRegistry instance.
  */
@@ -42,6 +59,12 @@ export interface HookRegistryOptions {
    * before being considered timed out. Default: 5000.
    */
   handlerTimeoutMs?: number;
+
+  /**
+   * Number of failures for a single event before a summary alert is logged.
+   * The alert fires once per threshold crossing. Default: 5.
+   */
+  failureAlertThreshold?: number;
 }
 
 /**
@@ -72,8 +95,18 @@ export class HookRegistry {
   /** Per-handler timeout */
   private handlerTimeoutMs: number;
 
+  /** Per-event failure/success statistics */
+  private stats: Map<string, HookEventStats> = new Map();
+
+  /** Failure threshold for repeated-failure alerting */
+  private failureAlertThreshold: number;
+
+  /** Tracks the last failure count at which an alert was fired per event */
+  private lastAlertedAt: Map<string, number> = new Map();
+
   constructor(options?: HookRegistryOptions) {
     this.handlerTimeoutMs = options?.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
+    this.failureAlertThreshold = options?.failureAlertThreshold ?? DEFAULT_FAILURE_ALERT_THRESHOLD;
   }
 
   /**
@@ -162,7 +195,12 @@ export class HookRegistry {
           label
         );
         successCount++;
+        this.recordSuccess(event);
       } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const isTimeout = errorMessage.includes('timed out');
+        this.recordFailure(event, label, errorMessage, isTimeout);
+
         logger.error(
           {
             event,
@@ -172,6 +210,13 @@ export class HookRegistry {
           },
           'Hook handler failed'
         );
+
+        if (CRITICAL_HOOKS.has(event)) {
+          logger.warn(
+            { event, label, critical: true, errorMessage },
+            'Critical hook handler failed'
+          );
+        }
       }
     }
 
@@ -273,7 +318,12 @@ export class HookRegistry {
           event,
           label
         );
+        this.recordSuccess(event);
       } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const isTimeout = errorMessage.includes('timed out');
+        this.recordFailure(event, label, errorMessage, isTimeout);
+
         logger.error(
           {
             event,
@@ -283,6 +333,13 @@ export class HookRegistry {
           },
           'Mutable hook handler failed'
         );
+
+        if (CRITICAL_HOOKS.has(event)) {
+          logger.warn(
+            { event, label, critical: true, errorMessage },
+            'Critical hook handler failed'
+          );
+        }
       }
     }
 
@@ -341,6 +398,77 @@ export class HookRegistry {
       events.add(key);
     }
     return Array.from(events) as HookEvent[];
+  }
+
+  // -------------------------------------------------------------------------
+  // Stats / observability
+  // -------------------------------------------------------------------------
+
+  /**
+   * Returns a snapshot of all per-event hook statistics plus aggregated totals.
+   */
+  getStats(): HookStats {
+    const events: Record<string, HookEventStats> = {};
+    let totalEmits = 0;
+    let totalFailures = 0;
+
+    for (const [event, eventStats] of this.stats) {
+      events[event] = { ...eventStats, lastFailure: eventStats.lastFailure ? { ...eventStats.lastFailure } : undefined };
+      totalEmits += eventStats.successCount + eventStats.failureCount;
+      totalFailures += eventStats.failureCount;
+    }
+
+    return { events, totalEmits, totalFailures };
+  }
+
+  /**
+   * Reset all statistics. Primarily useful for testing.
+   */
+  resetStats(): void {
+    this.stats.clear();
+    this.lastAlertedAt.clear();
+  }
+
+  /** Get or create the stats entry for an event */
+  private getOrCreateEventStats(event: string): HookEventStats {
+    let eventStats = this.stats.get(event);
+    if (!eventStats) {
+      eventStats = { successCount: 0, failureCount: 0, timeoutCount: 0 };
+      this.stats.set(event, eventStats);
+    }
+    return eventStats;
+  }
+
+  /** Record a successful handler execution */
+  private recordSuccess(event: string): void {
+    this.getOrCreateEventStats(event).successCount++;
+  }
+
+  /** Record a handler failure with optional timeout tracking and alerting */
+  private recordFailure(event: string, label: string, errorMessage: string, isTimeout: boolean): void {
+    const eventStats = this.getOrCreateEventStats(event);
+    eventStats.failureCount++;
+    eventStats.lastFailure = { error: errorMessage, label, timestamp: new Date().toISOString() };
+    if (isTimeout) {
+      eventStats.timeoutCount++;
+    }
+
+    // Check repeated-failure alert threshold
+    const lastAlerted = this.lastAlertedAt.get(event) ?? 0;
+    const nextThreshold = lastAlerted + this.failureAlertThreshold;
+    if (eventStats.failureCount >= nextThreshold) {
+      logger.warn(
+        {
+          event,
+          hookAlert: true,
+          failureCount: eventStats.failureCount,
+          timeoutCount: eventStats.timeoutCount,
+          lastFailure: eventStats.lastFailure,
+        },
+        `Hook "${event}" has reached ${eventStats.failureCount} failures`
+      );
+      this.lastAlertedAt.set(event, eventStats.failureCount);
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/packages/core/gateway/src/hooks/hook-types.ts
+++ b/packages/core/gateway/src/hooks/hook-types.ts
@@ -317,6 +317,29 @@ export type MutableHookHandler<E extends MutableHookEvent> = (
   payload: MutableHookPayloadMap[E]
 ) => Promise<void>;
 
+// ---------------------------------------------------------------------------
+// Hook Stats Types (for failure observability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-event statistics tracking success/failure counts and last failure details.
+ */
+export interface HookEventStats {
+  successCount: number;
+  failureCount: number;
+  lastFailure?: { error: string; label: string; timestamp: string };
+  timeoutCount: number;
+}
+
+/**
+ * Aggregated statistics across all hook events.
+ */
+export interface HookStats {
+  events: Record<string, HookEventStats>;
+  totalEmits: number;
+  totalFailures: number;
+}
+
 /**
  * Internal registration record used by HookRegistry.
  */

--- a/packages/core/gateway/src/hooks/index.ts
+++ b/packages/core/gateway/src/hooks/index.ts
@@ -49,6 +49,10 @@ export type {
   HookHandler,
   HookRegistration,
 
+  // Stats types
+  HookEventStats,
+  HookStats,
+
   // Mutable hook types
   MutableBeforeLLMRequestPayload,
   MutableBeforeResponseSentPayload,


### PR DESCRIPTION
## Summary

- **Per-event stats tracking** in `HookRegistry` — success/failure/timeout counts with `lastFailure` details
- **Critical hook warnings** — `session:created`, `message:received`, `gateway:startup`, `gateway:shutdown` failures emit structured `warn` logs with `critical: true`
- **Repeated-failure alerting** — configurable threshold (default: 5) fires a `hookAlert: true` warn once per crossing
- **Health endpoint integration** — `getHookStats()` wired into `/health` response; hook failures show as `checks.hooks: 'error'` without affecting overall gateway liveness
- **10 new tests** — 8 hook-registry stats tests, 2 health endpoint integration tests (all 50 pass, 0 type errors)

## Files changed (7)

| File | Change |
|------|--------|
| `hooks/hook-types.ts` | Added `HookEventStats`, `HookStats` interfaces |
| `hooks/hook-registry.ts` | Stats map, `recordSuccess`/`recordFailure`, `getStats()`, `resetStats()`, critical hook warn, alert threshold |
| `hooks/index.ts` | Export new types |
| `health.ts` | `getHookStats` in deps, hookStats in response |
| `gateway.ts` | Wire `getHookStats` into `performHealthCheck` |
| `hooks/hook-registry.test.ts` | 8 new stats tests |
| `health.test.ts` | 2 new hook stats integration tests |

## Test plan

- [x] `npx vitest run packages/core/gateway/src/hooks/hook-registry.test.ts` — 35 tests pass
- [x] `npx vitest run packages/core/gateway/src/health.test.ts` — 15 tests pass
- [x] Zero TypeScript type errors
- [ ] Verify `/health` endpoint includes `hookStats` in running gateway