### PR TITLE
fix(docker): build shared deps in correct order + update model names to 4.6

### DIFF
--- a/packages/channels/discord/Dockerfile
+++ b/packages/channels/discord/Dockerfile
@@ -10,7 +10,8 @@ COPY packages/shared/types ./packages/shared/types
 COPY packages/shared/utils ./packages/shared/utils
 
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter @nachos/config build
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/config build
 
 FROM node:22-alpine AS development
 
@@ -34,8 +35,16 @@ COPY --chown=nachos:nachos packages/channels/discord ./packages/channels/discord
 
 RUN pnpm install --frozen-lockfile
 
-COPY --chown=nachos:nachos . .
+# Inject pre-built config dist before building dependents
 COPY --from=config --chown=nachos:nachos /app/packages/shared/config/dist ./packages/shared/config/dist
+
+# Build shared deps in dependency order
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/bus build && \
+    pnpm --filter @nachos/channel-base build
+
+COPY --chown=nachos:nachos . .
 
 WORKDIR /app/packages/channels/discord
 CMD ["npx", "tsx", "watch", "src/main.ts"]

--- a/packages/channels/matrix/Dockerfile
+++ b/packages/channels/matrix/Dockerfile
@@ -10,7 +10,8 @@ COPY packages/shared/types ./packages/shared/types
 COPY packages/shared/utils ./packages/shared/utils
 
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter @nachos/config build
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/config build
 
 FROM node:22-alpine AS development
 
@@ -32,8 +33,15 @@ COPY --chown=nachos:nachos packages/channels/matrix ./packages/channels/matrix
 
 RUN pnpm install --frozen-lockfile
 
-COPY --chown=nachos:nachos . .
+# Inject pre-built config dist before building dependents
 COPY --from=config --chown=nachos:nachos /app/packages/shared/config/dist ./packages/shared/config/dist
+
+# Build shared deps in dependency order
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/bus build
+
+COPY --chown=nachos:nachos . .
 
 WORKDIR /app/packages/channels/matrix
 CMD ["npx", "tsx", "watch", "src/main.ts"]

--- a/packages/channels/slack/Dockerfile
+++ b/packages/channels/slack/Dockerfile
@@ -10,7 +10,8 @@ COPY packages/shared/types ./packages/shared/types
 COPY packages/shared/utils ./packages/shared/utils
 
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter @nachos/config build
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/config build
 
 FROM node:22-alpine AS development
 
@@ -32,8 +33,15 @@ COPY --chown=nachos:nachos packages/channels/slack ./packages/channels/slack
 
 RUN pnpm install --frozen-lockfile
 
-COPY --chown=nachos:nachos . .
+# Inject pre-built config dist before building dependents
 COPY --from=config --chown=nachos:nachos /app/packages/shared/config/dist ./packages/shared/config/dist
+
+# Build shared deps in dependency order
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/bus build
+
+COPY --chown=nachos:nachos . .
 
 WORKDIR /app/packages/channels/slack
 CMD ["npx", "tsx", "watch", "src/main.ts"]

--- a/packages/channels/telegram/Dockerfile
+++ b/packages/channels/telegram/Dockerfile
@@ -10,7 +10,8 @@ COPY packages/shared/types ./packages/shared/types
 COPY packages/shared/utils ./packages/shared/utils
 
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter @nachos/config build
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/config build
 
 FROM node:22-alpine AS development
 
@@ -32,8 +33,15 @@ COPY --chown=nachos:nachos packages/channels/telegram ./packages/channels/telegr
 
 RUN pnpm install --frozen-lockfile
 
-COPY --chown=nachos:nachos . .
+# Inject pre-built config dist before building dependents
 COPY --from=config --chown=nachos:nachos /app/packages/shared/config/dist ./packages/shared/config/dist
+
+# Build shared deps in dependency order
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/bus build
+
+COPY --chown=nachos:nachos . .
 
 WORKDIR /app/packages/channels/telegram
 CMD ["npx", "tsx", "watch", "src/main.ts"]

--- a/packages/channels/whatsapp/Dockerfile
+++ b/packages/channels/whatsapp/Dockerfile
@@ -10,7 +10,8 @@ COPY packages/shared/types ./packages/shared/types
 COPY packages/shared/utils ./packages/shared/utils
 
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter @nachos/config build
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/config build
 
 FROM node:22-alpine AS development
 
@@ -32,8 +33,15 @@ COPY --chown=nachos:nachos packages/channels/whatsapp ./packages/channels/whatsa
 
 RUN pnpm install --frozen-lockfile
 
-COPY --chown=nachos:nachos . .
+# Inject pre-built config dist before building dependents
 COPY --from=config --chown=nachos:nachos /app/packages/shared/config/dist ./packages/shared/config/dist
+
+# Build shared deps in dependency order
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/bus build
+
+COPY --chown=nachos:nachos . .
 
 WORKDIR /app/packages/channels/whatsapp
 CMD ["npx", "tsx", "watch", "src/main.ts"]

--- a/packages/core/gateway/Dockerfile
+++ b/packages/core/gateway/Dockerfile
@@ -17,8 +17,9 @@ COPY packages/shared/utils ./packages/shared/utils
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Build config package
-RUN pnpm --filter @nachos/config build
+# Build shared packages in dependency order
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/config build
 
 FROM node:22-alpine AS development
 

--- a/packages/core/llm-proxy/Dockerfile
+++ b/packages/core/llm-proxy/Dockerfile
@@ -10,7 +10,8 @@ COPY packages/shared/types ./packages/shared/types
 COPY packages/shared/utils ./packages/shared/utils
 
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter @nachos/config build
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/config build
 
 FROM node:22-alpine AS development
 
@@ -31,8 +32,15 @@ COPY --chown=nachos:nachos packages/core/llm-proxy ./packages/core/llm-proxy
 
 RUN pnpm install --frozen-lockfile
 
-COPY --chown=nachos:nachos . .
+# Inject pre-built config dist before building dependents
 COPY --from=config --chown=nachos:nachos /app/packages/shared/config/dist ./packages/shared/config/dist
+
+# Build shared deps in dependency order
+RUN pnpm --filter @nachos/types build && \
+    pnpm --filter @nachos/utils build && \
+    pnpm --filter @nachos/bus build
+
+COPY --chown=nachos:nachos . .
 
 EXPOSE 3001
 

--- a/packages/shared/config/README.md
+++ b/packages/shared/config/README.md
@@ -262,7 +262,7 @@ version = "1.0"
 
 [llm]
 provider = "anthropic"
-model = "claude-sonnet-4-20250514"
+model = "claude-sonnet-4-6"
 
 [security]
 mode = "standard"

--- a/packages/shared/config/src/loader.test.ts
+++ b/packages/shared/config/src/loader.test.ts
@@ -11,7 +11,7 @@ version = "1.0"
 
 [llm]
 provider = "anthropic"
-model = "claude-sonnet-4-20250514"
+model = "claude-sonnet-4-6"
 
 [security]
 mode = "standard"
@@ -22,7 +22,7 @@ mode = "standard"
       expect(config.nachos.name).toBe('test-assistant');
       expect(config.nachos.version).toBe('1.0');
       expect(config.llm.provider).toBe('anthropic');
-      expect(config.llm.model).toBe('claude-sonnet-4-20250514');
+      expect(config.llm.model).toBe('claude-sonnet-4-6');
       expect(config.security.mode).toBe('standard');
     });
 

--- a/packages/shared/config/src/plugin-config.test.ts
+++ b/packages/shared/config/src/plugin-config.test.ts
@@ -414,7 +414,7 @@ version = "1.0.0"
 
 [llm]
 provider = "anthropic"
-model = "claude-sonnet-4-20250514"
+model = "claude-sonnet-4-6"
 
 [security]
 mode = "standard"
@@ -446,7 +446,7 @@ version = "1.0.0"
 
 [llm]
 provider = "anthropic"
-model = "claude-sonnet-4-20250514"
+model = "claude-sonnet-4-6"
 
 [security]
 mode = "standard"
@@ -467,7 +467,7 @@ version = "1.0.0"
 
 [llm]
 provider = "anthropic"
-model = "claude-sonnet-4-20250514"
+model = "claude-sonnet-4-6"
 
 [security]
 mode = "standard"
@@ -493,7 +493,7 @@ version = "1.0.0"
 
 [llm]
 provider = "anthropic"
-model = "claude-sonnet-4-20250514"
+model = "claude-sonnet-4-6"
 
 [security]
 mode = "standard"
@@ -532,7 +532,7 @@ version = "1.0.0"
 
 [llm]
 provider = "anthropic"
-model = "claude-sonnet-4-20250514"
+model = "claude-sonnet-4-6"
 
 [security]
 mode = "standard"


### PR DESCRIPTION
## What

Fixes `ERR_MODULE_NOT_FOUND` errors crashing all channel/service containers on fresh build.

## Root Cause

Two related build-order bugs in all channel/service Dockerfiles:

1. **Config stage**: `@nachos/config build` ran before `@nachos/types build` — but config imports types, causing TS compile failure
2. **Dev stage**: Channel Dockerfiles built `@nachos/bus` and `@nachos/channel-base` before copying pre-built `config/dist` from the config stage

## Fix

- Build `@nachos/types` before `@nachos/config` in all Dockerfiles (config stage)
- Copy pre-built `config/dist` before running dev-stage builds
- Correct dep order in all channels: `types → utils → bus → channel-base`

## Also

- Updates stale `claude-sonnet-4-20250514` references to `claude-sonnet-4-6` in README and test fixtures

## Services Fixed

gateway, llm-proxy, discord, matrix, slack, telegram, whatsapp