### PR TITLE
fix(e2e): browser policy, audit path, code-runner workspace

### DIFF
--- a/packages/core/admin/src/routes/audit.ts
+++ b/packages/core/admin/src/routes/audit.ts
@@ -4,7 +4,8 @@ import { join } from 'node:path';
 import Database from 'better-sqlite3';
 import type { AuditRow, AuditResponse } from '../types.js';
 
-const STATE_DIR = process.env['NACHOS_STATE_DIR'] ?? '/app/state';
+// GATEWAY_STATE_DIR overrides for audit.db path (gateway writes audit to its own state dir)
+const STATE_DIR = process.env['GATEWAY_STATE_DIR'] ?? process.env['NACHOS_STATE_DIR'] ?? '/app/state';
 
 export const auditRouter = new Hono();
 

--- a/packages/tools/code-runner/Dockerfile
+++ b/packages/tools/code-runner/Dockerfile
@@ -8,7 +8,8 @@ RUN apk add --no-cache python3
 
 # Create non-root user early
 RUN adduser -D -u 1001 coderunner && \
-    mkdir -p /tmp && \
+    mkdir -p /tmp /workspace && \
+    chown coderunner:coderunner /workspace && \
     chown coderunner:coderunner /tmp
 
 WORKDIR /app

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -150,7 +150,31 @@ rules:
     priority: 800
     match:
       resource: "tool"
-      resourceId: "browser"
+      resourceId:
+        - "browser"
+        - "browser_navigate"
+        - "browser_screenshot"
+        - "browser_click"
+        - "browser_type"
+        - "browser_tab_new"
+        - "browser_tab_close"
+        - "browser_tab_list"
+        - "browser_tab_select"
+        - "browser_wait_for"
+        - "browser_close"
+        - "browser_resize"
+        - "browser_snapshot"
+        - "browser_pdf_save"
+        - "browser_network_requests"
+        - "browser_console_messages"
+        - "browser_file_upload"
+        - "browser_handle_dialog"
+        - "browser_evaluate"
+        - "browser_drag"
+        - "browser_scroll"
+        - "browser_hover"
+        - "browser_select_option"
+        - "browser_generate_playwright_test"
     effect: "allow"
 
   # Bitbucket tool - Standard tier, allows interaction with Bitbucket via REST API

--- a/policies/standard.yaml
+++ b/policies/standard.yaml
@@ -178,7 +178,31 @@ rules:
     priority: 800
     match:
       resource: "tool"
-      resourceId: "browser"
+      resourceId:
+        - "browser"
+        - "browser_navigate"
+        - "browser_screenshot"
+        - "browser_click"
+        - "browser_type"
+        - "browser_tab_new"
+        - "browser_tab_close"
+        - "browser_tab_list"
+        - "browser_tab_select"
+        - "browser_wait_for"
+        - "browser_close"
+        - "browser_resize"
+        - "browser_snapshot"
+        - "browser_pdf_save"
+        - "browser_network_requests"
+        - "browser_console_messages"
+        - "browser_file_upload"
+        - "browser_handle_dialog"
+        - "browser_evaluate"
+        - "browser_drag"
+        - "browser_scroll"
+        - "browser_hover"
+        - "browser_select_option"
+        - "browser_generate_playwright_test"
     effect: "allow"
 
   # Bitbucket tool - Standard tier, allows interaction with Bitbucket via REST API


### PR DESCRIPTION
## Fixes from NACA e2e testing

Three bugs surfaced during manual e2e testing:

### NACA-16 — Browser tool blocked by policy
Policy rules used `resourceId: "browser"` but Playwright MCP tools are named `browser_navigate`, `browser_screenshot`, etc. The Cheese evaluator does exact match on resourceId, so browser tools were always blocked. Expanded `resourceId` to array covering all `browser_*` tool names in `standard.yaml` and `permissive.yaml`.

### NACA-30 — Audit log not visible in admin UI
Gateway writes `audit.db` to its state directory, but the admin UI was reading from `NACHOS_STATE_DIR` which points to a different volume in the krkn3 deployment. Added `GATEWAY_STATE_DIR` env var support to the admin audit route — when set, it overrides `NACHOS_STATE_DIR` for audit DB path only.

### NACA-17 — Code runner Python ENOENT
Python executor spawns processes with `cwd: /workspace`, but `/workspace` directory did not exist in the container image. Added `mkdir -p /workspace` to the code-runner Dockerfile.