### PR TITLE
fix(dlp): correct DLP pattern names in example config + warn on unrecognized patterns

### DIFF
--- a/nachos.toml.example
+++ b/nachos.toml.example
@@ -246,11 +246,13 @@ mode = "standard"                         # "strict" | "standard" | "permissive"
 [security.dlp]
 enabled = true
 action = "warn"                           # "block" | "warn" | "audit" | "allow" | "redact"
+# Use DLP category names or specific pattern IDs from @nacho-labs/nachos-dlp
+# Categories: pii, api-keys, secrets, aws, private-keys, all
+# Pattern IDs: credit-card, ssn-us, credit-card-formatted, etc.
 patterns = [
-    "credit_card",
-    "ssn", 
-    "api_key",
-    "password"
+    "pii",
+    "api-keys",
+    "secrets"
 ]
 
 [security.approval]

--- a/packages/core/gateway/src/main.ts
+++ b/packages/core/gateway/src/main.ts
@@ -17,6 +17,7 @@ import { NatsBusAdapter } from './router.js';
 import type { StateLayerConfig } from '@nachos/state';
 import type { ContextManagementCommandsConfig, RuntimeConfig } from '@nachos/config';
 import path from 'node:path';
+import { patternCategories, patterns as dlpPatterns } from '@nacho-labs/nachos-dlp';
 
 async function buildDlpConfig(configPath?: string): Promise<DLPConfig | undefined> {
   const nachosConfig = loadAndValidateConfig({ configPath });
@@ -35,6 +36,19 @@ async function buildDlpConfig(configPath?: string): Promise<DLPConfig | undefine
         : action === 'allow'
           ? 'allow'
           : 'alert';
+
+  // Validate DLP pattern names — warn if any don't match a known category or pattern ID
+  if (dlp.patterns && dlp.patterns.length > 0) {
+    const knownCategories = new Set(Object.keys(patternCategories));
+    const knownIds = new Set(dlpPatterns.map((p) => p.id));
+    const unknown = dlp.patterns.filter((p) => !knownCategories.has(p) && !knownIds.has(p));
+    if (unknown.length > 0) {
+      console.warn(
+        `[nachos] DLP: Unrecognized pattern names in config (will load 0 patterns): ${unknown.join(', ')}. ` +
+          `Use category names (${[...knownCategories].join(', ')}) or specific pattern IDs.`
+      );
+    }
+  }
 
   return {
     ...base,


### PR DESCRIPTION
## Problem
DLP scanning never fired (NACA-21, NACA-22). Root cause: `nachos.toml.example` used underscore pattern names (`credit_card`, `ssn`) but `@nacho-labs/nachos-dlp` uses hyphen IDs (`credit-card`) and category names (`pii`, `api-keys`). Scanner loads 0 patterns and silently scans nothing.

## Fix
1. Updated `nachos.toml.example` to use correct category names: `pii`, `api-keys`, `secrets`
2. Added startup warning in `buildDlpConfig()` when configured pattern names don't match any known category or pattern ID

## Verified
- `Scanner({ patterns: ['credit_card'] }).patterns.length` → 0 (broken)
- `Scanner({ patterns: ['pii', 'api-keys'] }).patterns.length` → 61 (correct)

Fixes NACA-21, NACA-22