### PR TITLE
fix(cli): anyBins test coverage + actionable Docker error messages (#163)

### DIFF
--- a/packages/cli/src/core/errors.ts
+++ b/packages/cli/src/core/errors.ts
@@ -76,8 +76,55 @@ export class ComposeGenerationError extends CLIError {
   }
 }
 
+/**
+ * Known Docker error patterns and their user-friendly suggestions.
+ */
+const DOCKER_ERROR_SUGGESTIONS: Array<{ pattern: RegExp; suggestion: string }> = [
+  {
+    pattern: /cannot connect to the docker daemon|is the docker daemon running|docker daemon is not running/i,
+    suggestion:
+      'Docker daemon is not running. Start it with: open -a Docker (macOS) or sudo systemctl start docker (Linux)',
+  },
+  {
+    pattern: /permission denied.*\/var\/run\/docker\.sock/i,
+    suggestion:
+      'Permission denied accessing Docker socket. Add your user to the docker group: sudo usermod -aG docker $USER (then log out and back in)',
+  },
+  {
+    pattern: /no such file or directory.*docker/i,
+    suggestion: 'Docker binary not found. Install Docker Desktop or Docker Engine: https://docs.docker.com/get-docker/',
+  },
+  {
+    pattern: /pull access denied|manifest unknown|not found/i,
+    suggestion: 'Image could not be pulled. Check the image name/tag and your Docker Hub credentials.',
+  },
+  {
+    pattern: /port is already allocated|address already in use/i,
+    suggestion: 'A required port is already in use. Stop the conflicting service or change the port in nachos.toml.',
+  },
+  {
+    pattern: /no space left on device/i,
+    suggestion: 'Disk is full. Free up space or run: docker system prune',
+  },
+];
+
+function buildDockerSuggestion(stderr: string): string {
+  for (const { pattern, suggestion } of DOCKER_ERROR_SUGGESTIONS) {
+    if (pattern.test(stderr)) {
+      return suggestion;
+    }
+  }
+  // Fallback: show the raw error so users have something to act on
+  return `Docker reported: ${stderr.trim() || '(no error output)'}`;
+}
+
 export class DockerCommandError extends CLIError {
   constructor(command: string, stderr: string) {
-    super(`Docker command failed: ${command}`, 'DOCKER_COMMAND_FAILED', 3, `Error: ${stderr}`);
+    super(
+      `Docker command failed: ${command}`,
+      'DOCKER_COMMAND_FAILED',
+      3,
+      buildDockerSuggestion(stderr)
+    );
   }
 }

--- a/packages/core/gateway/src/skills/skill-loader.test.ts
+++ b/packages/core/gateway/src/skills/skill-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadSkills, formatSkillsForPrompt, filterSkillsForPrompt } from './skill-loader.js';
+import { loadSkills, formatSkillsForPrompt, filterSkillsForPrompt, type Skill } from './skill-loader.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -292,6 +292,119 @@ metadata: {invalid json here
       });
 
       expect(filtered).toHaveLength(0);
+    });
+
+    describe('anyBins requirement (OR logic)', () => {
+      function makeAnyBinsSkill(anyBins: string[]): Skill {
+        return {
+          name: 'any-bins-skill',
+          metadata: {
+            name: 'any-bins-skill',
+            description: 'Needs any one of several binaries',
+            nachos: { requires: { anyBins } },
+          },
+          content: '# Any bins skill',
+          filePath: '/test/any-bins-skill/SKILL.md',
+        };
+      }
+
+      it('should include skill when at least one anyBins binary is present', () => {
+        const skill = makeAnyBinsSkill(['curl', 'wget', 'httpie']);
+        const filtered = filterSkillsForPrompt([skill], {
+          hasBinary: (bin) => bin === 'wget', // only wget present
+        });
+        expect(filtered).toHaveLength(1);
+        expect(filtered[0]?.name).toBe('any-bins-skill');
+      });
+
+      it('should include skill when all anyBins binaries are present', () => {
+        const skill = makeAnyBinsSkill(['curl', 'wget']);
+        const filtered = filterSkillsForPrompt([skill], {
+          hasBinary: () => true, // all binaries present
+        });
+        expect(filtered).toHaveLength(1);
+      });
+
+      it('should exclude skill when no anyBins binary is present', () => {
+        const skill = makeAnyBinsSkill(['curl', 'wget', 'httpie']);
+        const filtered = filterSkillsForPrompt([skill], {
+          hasBinary: () => false, // nothing available
+        });
+        expect(filtered).toHaveLength(0);
+      });
+
+      it('should include skill when anyBins is empty (no OR requirement)', () => {
+        const skill = makeAnyBinsSkill([]);
+        const filtered = filterSkillsForPrompt([skill], {
+          hasBinary: () => false,
+        });
+        // Empty anyBins means no OR constraint — skill should pass
+        expect(filtered).toHaveLength(1);
+      });
+
+      it('should apply anyBins independently from bins (AND) requirements', () => {
+        const skill: Skill = {
+          name: 'combined',
+          metadata: {
+            name: 'combined',
+            description: 'Needs bin1 AND (curl OR wget)',
+            nachos: { requires: { bins: ['bin1'], anyBins: ['curl', 'wget'] } },
+          },
+          content: '# Combined',
+          filePath: '/test/combined/SKILL.md',
+        };
+
+        // bin1 present, curl present → include
+        const included = filterSkillsForPrompt([skill], {
+          hasBinary: (bin) => bin === 'bin1' || bin === 'curl',
+        });
+        expect(included).toHaveLength(1);
+
+        // bin1 present, neither curl nor wget → exclude (anyBins not satisfied)
+        const excluded = filterSkillsForPrompt([skill], {
+          hasBinary: (bin) => bin === 'bin1',
+        });
+        expect(excluded).toHaveLength(0);
+
+        // curl present, bin1 missing → exclude (bins not satisfied)
+        const excludedNoBin1 = filterSkillsForPrompt([skill], {
+          hasBinary: (bin) => bin === 'curl',
+        });
+        expect(excludedNoBin1).toHaveLength(0);
+      });
+
+      it('should handle anyBins parsed from SKILL.md frontmatter metadata', () => {
+        const skillDir = path.join(tempDir, 'anybins-parsed');
+        fs.mkdirSync(skillDir);
+
+        const skillContent = `---
+name: anybins-parsed
+description: Uses anyBins from frontmatter
+metadata: {"nachos":{"requires":{"anyBins":["jq","yq"]}}}
+---
+
+# anybins-parsed
+
+Requires jq or yq.
+`;
+        fs.writeFileSync(path.join(skillDir, 'SKILL.md'), skillContent);
+
+        const skills = loadSkills({ skillsDir: tempDir });
+        expect(skills).toHaveLength(1);
+        expect(skills[0]?.metadata.nachos?.requires?.anyBins).toEqual(['jq', 'yq']);
+
+        // Only jq present → skill should load via filterSkillsForPrompt
+        const filtered = filterSkillsForPrompt(skills, {
+          hasBinary: (bin) => bin === 'jq',
+        });
+        expect(filtered).toHaveLength(1);
+
+        // Neither present → excluded
+        const excluded = filterSkillsForPrompt(skills, {
+          hasBinary: () => false,
+        });
+        expect(excluded).toHaveLength(0);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes two of the three findings from #163:

### Finding #47 — `anyBins` skill requirement test coverage
The `anyBins` (OR condition: at least one binary required) logic was already implemented in `filterSkillsForPrompt` but had **zero test coverage**. Added 6 tests covering:
- Include when at least one `anyBins` binary is present ✓
- Include when all `anyBins` binaries are present ✓
- Exclude when no `anyBins` binary is present ✓
- Empty `anyBins` passes through (no OR constraint) ✓
- `anyBins` + `bins` (AND+OR combined) correctly requires both ✓
- Round-trip: `anyBins` parsed from SKILL.md frontmatter metadata ✓

### Finding #46 — Docker client error handling insufficient
Replaced the raw `Error: <stderr>` suggestion in `DockerCommandError` with pattern-matched, user-actionable messages for 6 known failure categories:
- **Daemon not running** → platform-specific start command
- **Socket permission denied** → `usermod -aG docker` suggestion
- **Binary not found** → install docs link
- **Image pull failure** → check name/tag/credentials hint
- **Port in use** → stop conflicting service or change config
- **Disk full** → `docker system prune`
- **Fallback** → raw stderr (users always have something to act on)

### Finding #49 — Plugin manifest signature verification
Skipping for now — the issue notes this as "not blocking, but defense in depth" and it's a larger scope requiring design decisions about key management. Leaving for a future iteration.

## Tests
- `skill-loader.test.ts`: 14 → 20 tests, all passing
- CLI command tests: all passing, no regressions in Docker error paths