### PR TITLE
fix: NACA-64 skills.reloaded envelope + gateway Dockerfile gh CLI

### DIFF
--- a/packages/core/gateway/Dockerfile
+++ b/packages/core/gateway/Dockerfile
@@ -27,8 +27,12 @@ FROM node:22-slim AS development
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     ca-certificates \
+    curl \
     chromium \
     fonts-freefont-ttf \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Point playwright-core at system Chromium

--- a/packages/core/gateway/src/skills/skills-manager.ts
+++ b/packages/core/gateway/src/skills/skills-manager.ts
@@ -9,6 +9,7 @@ import type { Skill } from './skill-loader.js';
 import type { SkillWatcher } from './skill-watcher.js';
 import type { SkillToolConfig } from '../tools/shell-tool.js';
 import type { NatsBusAdapter } from '../router.js';
+import { createEnvelope } from '../router.js';
 
 const logger = createLogger('skills-manager');
 
@@ -174,14 +175,17 @@ export class SkillsManager {
     try {
       const bus = this.deps.getBus();
       if (bus) {
-        await bus.publish(TOPICS.skills.reloaded, {
-          event: 'skills.reloaded',
-          added,
-          removed,
-          modified,
-          total: current.length,
-          timestamp: Date.now(),
-        });
+        await bus.publish(
+          TOPICS.skills.reloaded,
+          createEnvelope('gateway', 'skills.reloaded', {
+            event: 'skills.reloaded',
+            added,
+            removed,
+            modified,
+            total: current.length,
+            timestamp: Date.now(),
+          })
+        );
       }
     } catch (error) {
       logger.error({ err: error }, 'Failed to publish skills.reloaded event');


### PR DESCRIPTION
## Summary

Fixes two issues found during e2e testing (NACA-29 bug bash):

### NACA-64: skills.reloaded publish fails with Invalid message envelope

**Root cause:** `SkillsManager.handleSkillReload()` called `NatsBusAdapter.publish()` with a plain object, but `NatsBusAdapter` requires a `MessageEnvelope` (with `id`, `timestamp`, `source`, `type`, `payload` fields).

**Fix:** Import `createEnvelope` from `router.ts` and wrap the skills payload before publishing.

**Tested:** Skill hot reload now completes without error. `skills.reloaded` event publishes successfully.

### Dockerfile: bake gh CLI into gateway image

**Problem:** The GitHub tool (`tools.github`) uses `gh` CLI, which was not installed in the gateway Docker image. Required manual `apt-get install gh` on every container restart.

**Fix:** Add `gh` CLI installation to the `development` build stage in `packages/core/gateway/Dockerfile`.

**Tested:** `gh version 2.88.1` confirmed in rebuilt image without manual install. GitHub tool e2e tests pass.