### PR TITLE
feat: expose sandboxMode per-spawn + wire shell tool rate limit from config

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -369,6 +369,18 @@ Tool configurations. Each tool is independently enabled/disabled.
 | Key | Type | Description |
 |-----|------|-------------|
 | `enabled` | boolean | Enable shell access (**requires permissive mode**) |
+| `rate_limit.max_per_window` | number | Max exec calls per user per window (e.g. `10`) |
+| `rate_limit.window_ms` | number | Rate limit window in ms (default: `60000`) |
+
+Example:
+```toml
+[tools.shell]
+enabled = true
+
+[tools.shell.rate_limit]
+max_per_window = 10
+window_ms = 60000
+```
 
 #### `[tools.web_search]`
 
@@ -667,7 +679,9 @@ Tier names: `archival`, `compressed`, `condensed`.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `mode` | string | `host`, `tool`, `full` |
+| `mode` | string | `host` (default — runs in main container), `full` (isolated Docker container) |
+
+> **Per-spawn override:** Pass `sandboxMode: "host"` or `sandboxMode: "full"` in the `sessions_spawn` tool call to override the global sandbox mode for a specific subagent.
 
 **`[runtime.subagents.sandbox.docker]`** (required when `mode = "full"`)
 

--- a/packages/core/gateway/src/gateway.ts
+++ b/packages/core/gateway/src/gateway.ts
@@ -2462,6 +2462,14 @@ export class Gateway {
       shellConfig: {
         allowedTools: skillToolConfigs,
         securityMode,
+        ...(this.toolsConfig?.shell?.rate_limit
+          ? {
+              rateLimit: {
+                maxPerWindow: this.toolsConfig.shell.rate_limit.max_per_window,
+                windowMs: this.toolsConfig.shell.rate_limit.window_ms ?? 60_000,
+              },
+            }
+          : {}),
       },
     });
     this.localToolHandler = localToolHandler;

--- a/packages/core/gateway/src/tools/tool-executor.ts
+++ b/packages/core/gateway/src/tools/tool-executor.ts
@@ -855,6 +855,9 @@ export class ToolExecutor {
         typeof call.parameters.stream === 'boolean' ? call.parameters.stream : undefined;
       const cleanup = readCleanup(call.parameters.cleanup);
       const timeoutMs = readTimeoutMs(call.parameters.runTimeoutSeconds);
+      const sandboxModeRaw = readOptionalString(call.parameters.sandboxMode);
+      const sandboxMode =
+        sandboxModeRaw === 'host' || sandboxModeRaw === 'full' ? sandboxModeRaw : undefined;
 
       const runRequest: SubagentRunRequest = {
         task,
@@ -866,6 +869,7 @@ export class ToolExecutor {
         stream,
         cleanup,
         timeoutMs,
+        sandboxMode,
         sessionConfig: session.config,
         requester: {
           sessionId: session.id,

--- a/packages/shared/config/src/index.ts
+++ b/packages/shared/config/src/index.ts
@@ -29,6 +29,7 @@ export type {
   BrowserToolConfig,
   CodeRunnerToolConfig,
   ShellToolConfig,
+  ShellRateLimitConfig,
   WebSearchToolConfig,
   WebFetchToolConfig,
 

--- a/packages/shared/config/src/schema.ts
+++ b/packages/shared/config/src/schema.ts
@@ -216,8 +216,17 @@ export interface CodeRunnerToolConfig {
 /**
  * Shell tool configuration
  */
+export interface ShellRateLimitConfig {
+  /** Maximum exec calls per window per user+tool combination */
+  max_per_window: number;
+  /** Window duration in milliseconds (default: 60000) */
+  window_ms?: number;
+}
+
 export interface ShellToolConfig {
   enabled: boolean;
+  /** Per-user rate limiting for exec/shell calls */
+  rate_limit?: ShellRateLimitConfig;
 }
 
 /**

--- a/packages/shared/config/src/validation.ts
+++ b/packages/shared/config/src/validation.ts
@@ -133,7 +133,10 @@ const CONFIG_SHAPE: SchemaNode = {
     filesystem: { enabled: true, paths: true, write: true, max_file_size: true },
     browser: { enabled: true, allowed_domains: true, headless: true, timeout: true },
     code_runner: { enabled: true, runtime: true, languages: true, timeout: true, max_memory: true },
-    shell: { enabled: true },
+    shell: {
+      enabled: true,
+      rate_limit: { max_per_window: true, window_ms: true },
+    },
     web_search: {
       enabled: true,
       api_key_env: true,

--- a/packages/shared/types/src/schemas.ts
+++ b/packages/shared/types/src/schemas.ts
@@ -612,6 +612,12 @@ export const SessionsSpawnToolSchema = Type.Object(
         description: 'Whether to delete or keep the subagent session after completion',
       })
     ),
+    sandboxMode: Type.Optional(
+      Type.Union([Type.Literal('host'), Type.Literal('full')], {
+        description:
+          'Sandbox isolation mode. "host" runs in the main container (default). "full" runs in an isolated Docker container (requires docker config).',
+      })
+    ),
   },
   { $id: 'SessionsSpawnTool', description: 'Subagent spawn tool parameters' }
 );


### PR DESCRIPTION
Two implementation gaps found during e2e testing:

## sessions_spawn sandboxMode
The `sandboxMode` field existed in `SubagentTask` and was wired through the orchestrator/manager, but was never exposed as a parameter in the `sessions_spawn` LLM tool schema. The LLM had no way to request a specific sandbox mode per spawn.

**Fix:** Add `sandboxMode: "host" | "full"` to `SessionsSpawnToolSchema` and read it in the tool-executor spawn handler.

## Shell tool rate limit
The `rateLimit` config option existed in `ShellTool` but was never read from the nachos.toml config. Operators had no way to configure per-user shell rate limiting — it was always unlimited.

**Fix:** Add `rate_limit` to `ShellToolConfig` schema, wire it through `gateway.ts` → `LocalToolHandler` → `ShellTool`.

Example:
```toml
[tools.shell.rate_limit]
max_per_window = 10
window_ms = 60000
```