### PR TITLE
fix: critical docs errors, NATS leak, dead code removal

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -95,6 +95,7 @@ LLM provider configuration. Credentials come from `.env`.
 | `temperature` | number | no | — | 0–2 |
 | `base_url` | string | no | — | Required for `ollama`/`custom` providers |
 | `region` | string | no | — | Required for `bedrock` provider |
+| `context_window` | number | no | — | Override the model's context window size in tokens |
 
 #### `[[llm.profiles]]` — Auth Profiles
 
@@ -106,16 +107,6 @@ Tried in `profile_order` sequence until one succeeds.
 | `provider` | string | yes | Provider name |
 | `api_key_env` | string | yes | Environment variable containing the API key |
 | `base_url` | string | no | Override base URL for this profile |
-
-#### `[[llm.providers]]` — Provider Definitions
-
-| Key | Type | Required | Description |
-|-----|------|----------|-------------|
-| `name` | string | yes | Provider identifier |
-| `type` | string | yes | Provider type |
-| `base_url` | string | no | API base URL |
-| `models` | string[] | no | Available models |
-| `profiles` | string[] | no | Associated auth profiles |
 
 #### `[llm.retry]`
 
@@ -218,7 +209,7 @@ mode = "standard"
 
 [security.dlp]
 enabled = true
-action = "block"  # default action — also supports "allow", "block", "redact", "alert"
+action = "block"  # default action — also supports "allow", "block", "redact", "warn", "audit"
 patterns = ["credit_card", "ssn", "api_key", "password"]
 
 [security.rate_limits]
@@ -682,7 +673,6 @@ Tier names: `archival`, `compressed`, `condensed`.
 |-----|------|-------------|
 | `name` | string | Assistant display name |
 | `system_prompt` | string | System prompt (supports multi-line `"""..."""`) |
-| `context_files` | string[] | Additional context file paths |
 
 ---
 
@@ -718,6 +708,36 @@ Skill-backed CLI tool configuration.
 | `check_interval_seconds` | number | How often to check for due tasks |
 | `max_concurrent_jobs` | number | Max concurrent jobs |
 | `run_missed_on_startup` | boolean | Run missed jobs on startup |
+
+#### `[[scheduler.jobs]]` — Scheduled Job Definitions
+
+Array of declarative job definitions synced to the SQLite job registry on startup.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | string | yes | Unique job identifier |
+| `description` | string | no | Human-readable description |
+| `schedule_type` | string | yes | `at` (one-shot ISO timestamp), `every` (interval ms), `cron` (5-field cron) |
+| `schedule_value` | string | yes | ISO timestamp, milliseconds, or cron expression |
+| `timezone` | string | no | IANA timezone for cron schedules |
+| `action_type` | string | yes | `systemEvent` or `agentTurn` |
+| `action_text` | string | no | Text to inject (for `systemEvent`) |
+| `action_prompt` | string | no | Prompt for the LLM (for `agentTurn`) |
+| `delivery_channel` | string | no | Target channel to deliver job output |
+| `enabled` | boolean | no | Whether this job is active |
+
+---
+
+### `[sessions]` — Optional
+
+Session lifecycle configuration.
+
+#### `[sessions]`
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `inactivity_timeout` | number | Close inactive sessions after this many seconds |
+| `archive_ttl` | number | Delete archived sessions after this many seconds |
 
 ---
 

--- a/packages/core/admin/README.md
+++ b/packages/core/admin/README.md
@@ -58,7 +58,7 @@ Backend: `http://localhost:8082`
 | `NACHOS_CONFIG_PATH` | `/app/nachos.toml` | Path to config file |
 | `NACHOS_STATE_DIR` | `/app/state` | Directory containing `nachos.db` and `audit.db` |
 | `NACHOS_SKILLS_DIR` | `/app/skills` | Directory scanned for `SKILL.md` files |
-| `NACHOS_ADMIN_TOKEN` | *(unset)* | Auth token. If unset, API is open (warning printed at startup) |
+| `NACHOS_ADMIN_TOKEN` | *(unset)* | Auth token. Always required — if unset, a random session token is generated at startup and printed to logs |
 | `GATEWAY_HEALTH_URL` | `http://gateway:3000/health` | Gateway health endpoint |
 
 ## API Reference

--- a/packages/core/admin/src/routes/chat.ts
+++ b/packages/core/admin/src/routes/chat.ts
@@ -176,6 +176,10 @@ chatRouter.get('/stream', async (c) => {
       await new Promise<void>((resolve) => {
         stream.onAbort(() => {
           clearInterval(keepAlive);
+          // Unsubscribe from NATS to prevent subscription leak
+          bus.unsubscribe(outboundTopic).catch((err) => {
+            logger.error({ err }, 'Failed to unsubscribe outbound topic on disconnect');
+          });
           resolve();
         });
       });

--- a/packages/core/admin/src/routes/config.ts
+++ b/packages/core/admin/src/routes/config.ts
@@ -52,13 +52,13 @@ configRouter.put('/', async (c) => {
       );
     }
 
-    const dlp = parsed['dlp'] as Record<string, unknown> | undefined;
-    if (dlp && dlp['default_action'] === 'allow') {
+    const dlp = security?.['dlp'] as Record<string, unknown> | undefined;
+    if (dlp && dlp['action'] === 'allow') {
       return c.json(
         {
           error: 'Security policy violation',
           details:
-            'Cannot set DLP default_action to "allow" via the API. Edit nachos.toml directly.',
+            'Cannot set [security.dlp] action to "allow" via the API. Edit nachos.toml directly.',
         },
         403
       );
@@ -103,11 +103,11 @@ configRouter.patch('/', async (c) => {
       403
     );
   }
-  if (body.path === 'dlp.default_action' && body.value === 'allow') {
+  if (body.path === 'security.dlp.action' && body.value === 'allow') {
     return c.json(
       {
         error: 'Security policy violation',
-        details: 'Cannot set DLP default_action to "allow" via the API. Edit nachos.toml directly.',
+        details: 'Cannot set [security.dlp] action to "allow" via the API. Edit nachos.toml directly.',
       },
       403
     );

--- a/packages/core/gateway/src/gateway.ts
+++ b/packages/core/gateway/src/gateway.ts
@@ -269,7 +269,6 @@ export class Gateway {
   private stateLayer?: StateLayer;
   private _stateLayerInitPromise?: Promise<void>;
   private memoryPipeline?: MemoryPipeline;
-  private memoryPipelineInterval?: NodeJS.Timeout;
   private sessionSweeperInterval?: NodeJS.Timeout;
   private sessionsLifecycleConfig?: SessionsLifecycleConfig;
   private securityMode: 'strict' | 'standard' | 'permissive';
@@ -1772,8 +1771,8 @@ export class Gateway {
         if (job.actionType === 'agentTurn') {
           const actionData = job.actionData as import('./scheduler/types.js').AgentTurnAction;
 
-          // Create an isolated agent turn (similar to how subagents work)
-          // For now, inject as a system event - can be enhanced later for true isolated turns
+          // agentTurn is currently implemented as a channel inbound injection.
+          // model/temperature from actionData are not yet honored — tracked for future improvement.
           if (job.deliveryChannel) {
             const message: ChannelInboundMessage = {
               channel: job.deliveryChannel,
@@ -2509,7 +2508,6 @@ export class Gateway {
 
     await this.registerManagementHandlers();
 
-    this.startMemoryPipelineScheduler();
     this.startSessionSweeper();
     await this.router.getBus().subscribe(TOPICS.config.update, async (data) => {
       await this.handleConfigUpdate(data);
@@ -2744,11 +2742,6 @@ export class Gateway {
       await this.rateLimiter.shutdown();
     }
 
-    if (this.memoryPipelineInterval) {
-      clearInterval(this.memoryPipelineInterval);
-      this.memoryPipelineInterval = undefined;
-    }
-
     if (this.sessionSweeperInterval) {
       clearInterval(this.sessionSweeperInterval);
       this.sessionSweeperInterval = undefined;
@@ -2862,17 +2855,6 @@ export class Gateway {
     } catch (err) {
       logger.warn({ err, eventType: event.eventType }, 'Failed to log audit event');
     }
-  }
-
-  /**
-   * @deprecated Periodic DLP extraction replaced by session-end LLM extraction (startSessionSweeper).
-   * Kept as no-op for backward compatibility — will be removed in a future release.
-   */
-  private startMemoryPipelineScheduler(): void {
-    // No-op: periodic extraction is now handled by session-end LLM extraction.
-    // The session sweeper (startSessionSweeper) closes inactive sessions and triggers
-    // knowledge extraction via onSessionClosed().
-    // Compaction-based extraction in router.ts still uses MemoryPipeline.storeExtracted() directly.
   }
 
   /**
@@ -3052,14 +3034,6 @@ export class Gateway {
       if (!response?.success || !response.message) return '';
       return coerceLLMContentText(response.message.content) ?? '';
     };
-  }
-
-  /**
-   * Get the sessions store
-   * @deprecated Use getSessionsStore() instead
-   */
-  getStorage(): SessionsStore {
-    return this.sessionsStore;
   }
 
   /**

--- a/packages/core/gateway/src/tools/tool-executor.ts
+++ b/packages/core/gateway/src/tools/tool-executor.ts
@@ -508,10 +508,12 @@ export class ToolExecutor {
     const blockedResults: Array<{ index: number; result: ToolResult }> = [];
     const allowedCalls: Array<{ index: number; call: ToolCall }> = [];
     const localResults: Array<{ index: number; result: ToolResult }> = [];
+    const callStartTimes = new Map<string, number>();
 
     for (let i = 0; i < calls.length; i += 1) {
       const call = calls[i];
       if (!call) continue;
+      callStartTimes.set(call.id, Date.now());
 
       // -----------------------------------------------------------------------
       // Basic tool call validation (#148)
@@ -778,7 +780,7 @@ export class ToolExecutor {
             error: result?.error
               ? { code: result.error.code, message: result.error.message }
               : undefined,
-            durationMs: 0,
+            durationMs: Date.now() - (callStartTimes.get(call.id) ?? Date.now()),
             timestamp: new Date().toISOString(),
           });
         } catch (hookError) {

--- a/packages/shared/config/src/index.ts
+++ b/packages/shared/config/src/index.ts
@@ -74,7 +74,6 @@ export type {
   SubagentToolProfileConfig,
   SubagentToolPolicyConfig,
   RuntimeToolSandboxConfig,
-  SelfManagementConfig,
   AssistantConfig,
   SkillsConfig,
   SkillEntryConfig,

--- a/packages/shared/config/src/schema.ts
+++ b/packages/shared/config/src/schema.ts
@@ -694,15 +694,6 @@ export interface RuntimeToolSandboxConfig {
 }
 
 /**
- * Self-management configuration for DevOps capability
- */
-export interface SelfManagementConfig {
-  enabled?: boolean;
-  source_dir?: string;
-  require_confirmation_for_restart?: boolean;
-}
-
-/**
  * Runtime configuration
  */
 export interface RuntimeConfig {
@@ -721,7 +712,6 @@ export interface RuntimeConfig {
   state?: StateLayerConfig;
   subagents?: SubagentConfig;
   sandbox?: RuntimeToolSandboxConfig;
-  self_management?: SelfManagementConfig;
 }
 
 /**

--- a/packages/shared/config/src/validation.ts
+++ b/packages/shared/config/src/validation.ts
@@ -36,6 +36,7 @@ const CONFIG_SHAPE: SchemaNode = {
     temperature: true,
     base_url: true,
     region: true, // AWS region for Bedrock provider
+    context_window: true,
   },
   channels: {
     webchat: { enabled: true, port: true },
@@ -304,6 +305,7 @@ const CONFIG_SHAPE: SchemaNode = {
         reset_triggers: true,
         context_triggers: true,
         identity_triggers: true,
+        help_triggers: true,
       },
     },
     state: {
@@ -404,11 +406,6 @@ const CONFIG_SHAPE: SchemaNode = {
       env: true,
       setup_command: true,
       network: true,
-    },
-    self_management: {
-      enabled: true,
-      source_dir: true,
-      require_confirmation_for_restart: true,
     },
   },
   assistant: { name: true, system_prompt: true },


### PR DESCRIPTION
Fixes from automated codebase audit. Changes grouped by impact:

## 🔴 Critical — docs that break startup

- **Remove `[[llm.providers]]`** from CONFIGURATION.md — validation actively rejects it (test proves it)
- **Remove `assistant.context_files`** row from docs — same, validation rejects it with a test
- **Add `llm.context_window`** to validation CONFIG_SHAPE — it works in gateway code but validation was blocking it at startup
- **Add `help_triggers`** to validation CONFIG_SHAPE — same, works but was rejected

## 🟠 High — real bugs

- **Fix NATS subscription leak** in webchat SSE (`admin/src/routes/chat.ts`) — subscriptions were never unsubscribed on disconnect, accumulating for the lifetime of the process
- **Fix DLP config guard** in admin config route — was checking `dlp.default_action` (nonexistent key), now checks `security.dlp.action` (correct)
- **Fix `durationMs: 0`** hardcoded in `tool:after-call` hook — now tracks actual elapsed ms per tool call

## 📄 Docs gaps

- Add `[sessions]` lifecycle config section (real feature, zero docs)
- Add `[[scheduler.jobs]]` declarative jobs section (real feature, zero docs)  
- Add `context_window` to `[llm]` table
- Fix DLP action comment (listed `alert` which fails validation)
- Fix admin README (said API was open when token unset — it's always protected)

## 🧹 Dead code

- Remove `getStorage()` deprecated method (nothing calls it)
- Remove `memoryPipelineInterval` field + dead clear in `stop()` + no-op `startMemoryPipelineScheduler()`
- Remove `SelfManagementConfig` from schema/validation (scaffolded but never consumed)
- Fix `agentTurn` scheduler comment (said 'isolated turns', actually just injects inbound message)