### PR TITLE
fix: typing indicators always subscribed; code runner cwd falls back to /tmp

### DIFF
--- a/packages/channels/discord/src/index.ts
+++ b/packages/channels/discord/src/index.ts
@@ -104,7 +104,11 @@ export class DiscordChannelAdapter implements ChannelAdapter {
       await this.sendMessage(payload as OutboundMessage);
     });
 
-    if (this.channelConfig?.status_emojis?.enabled) {
+    // Subscribe to status events if typing indicators OR status emojis are enabled.
+    // Typing indicators are on by default; status_emojis require explicit opt-in.
+    const typingEnabled = this.channelConfig?.typing_indicators !== false;
+    const emojisEnabled = this.channelConfig?.status_emojis?.enabled === true;
+    if (typingEnabled || emojisEnabled) {
       await this.subscribeToStatusEvents();
     }
   }

--- a/packages/tools/code-runner/src/__tests__/javascript-executor.test.ts
+++ b/packages/tools/code-runner/src/__tests__/javascript-executor.test.ts
@@ -41,6 +41,7 @@ vi.mock('@nachos/types', () => ({
 
 // Mock fs for createTempScript/cleanupTempScript
 vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true), // /workspace exists in test env
   promises: {
     mkdir: vi.fn().mockResolvedValue(undefined),
     writeFile: vi.fn().mockResolvedValue(undefined),

--- a/packages/tools/code-runner/src/__tests__/python-executor.test.ts
+++ b/packages/tools/code-runner/src/__tests__/python-executor.test.ts
@@ -41,6 +41,7 @@ vi.mock('@nachos/types', () => ({
 
 // Mock fs for createTempScript/cleanupTempScript
 vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true), // /workspace exists in test env
   promises: {
     mkdir: vi.fn().mockResolvedValue(undefined),
     writeFile: vi.fn().mockResolvedValue(undefined),

--- a/packages/tools/code-runner/src/javascript-executor.ts
+++ b/packages/tools/code-runner/src/javascript-executor.ts
@@ -10,6 +10,7 @@
  */
 
 import { spawn } from 'child_process';
+import { existsSync } from 'fs';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
@@ -250,7 +251,7 @@ export class JavaScriptExecutor extends ToolService {
       // Spawn Node.js process with restricted environment
       const proc = spawn(command, args, {
         timeout: timeoutMs,
-        cwd: workdir === '/tmp' ? '/workspace' : workdir,
+        cwd: workdir === '/tmp' ? (existsSync('/workspace') ? '/workspace' : '/tmp') : workdir,
         env: {
           PATH: '/usr/local/bin:/usr/bin:/bin',
           NODE_ENV: 'production',

--- a/packages/tools/code-runner/src/python-executor.ts
+++ b/packages/tools/code-runner/src/python-executor.ts
@@ -10,7 +10,7 @@
  */
 
 import { spawn } from 'child_process';
-import { promises as fs } from 'fs';
+import { promises as fs, existsSync } from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { ToolService } from '@nachos/tool-base';
@@ -250,7 +250,7 @@ export class PythonExecutor extends ToolService {
       // Spawn Python process with restricted environment
       const proc = spawn(command, args, {
         timeout: timeoutMs,
-        cwd: workdir === '/tmp' ? '/workspace' : workdir,
+        cwd: workdir === '/tmp' ? (existsSync('/workspace') ? '/workspace' : '/tmp') : workdir,
         env: {
           PATH: '/usr/local/bin:/usr/bin:/bin',
           PYTHONDONTWRITEBYTECODE: '1', // Don't create .pyc files


### PR DESCRIPTION
## Problems Fixed

### 1. Typing indicators never fired
Status event subscription in the Discord adapter was gated behind `status_emojis.enabled`. Typing indicators use the same events but were never explicitly opt-in — they default to `true`. Net result: unless you had `[channels.discord.status_emojis] enabled = true` in nachos.toml, typing indicators silently never subscribed and never showed.

**Fix:** Subscribe to status events when `typing_indicators !== false` OR `status_emojis.enabled === true` — decoupling the two features.

### 2. Code runner always failed (spawn ENOENT)
Both `python-executor` and `javascript-executor` defaulted to `/workspace` as the cwd for spawned processes. The code-runner containers don't have `/workspace` mounted — that directory only exists in the gateway/filesystem containers. `spawn()` fails immediately with ENOENT when the cwd doesn't exist, so `print(sum([1,2,3,4,5]))` → error instead of `15`.

**Fix:** `existsSync('/workspace') ? '/workspace' : '/tmp'` — falls back to `/tmp` transparently. Containers with a workspace volume still use it.

## Verification
- Typing indicators: confirmed `nachos.status.*.thinking/tool/done` events flow through NATS and Discord adapter now subscribes
- Code runner: direct NATS request/reply returns `15` in ~17ms; end-to-end test via gateway also returns `15`
- JS runner: same fix, same verification (`console.log([1,2,3,4,5].reduce((a,b)=>a+b,0))` → `15`)