### PR TITLE
chore: remove claude_code_mcp and firecrawl (unsupported)

### DIFF
--- a/nachos.toml.example
+++ b/nachos.toml.example
@@ -178,13 +178,6 @@ timeout_seconds = 30
 max_redirects = 3
 # user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
 
-[tools.web_fetch.firecrawl]
-enabled = false
-# api_key = "${FIRECRAWL_API_KEY}"
-# base_url = "https://api.firecrawl.dev"
-only_main_content = true
-max_age_ms = 86400000
-timeout_seconds = 60
 
 [tools.github]
 enabled = false
@@ -224,9 +217,6 @@ tools = ["summarize"]
 [tools.groups.workspace]
 tools = ["gog"]
 
-[tools.claude_code_mcp]
-enabled = true
-max_prompt_length = 4000
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 🌶️ THE CHEESE - Security Configuration

--- a/packages/core/admin/frontend/src/pages/ConfigPage.vue
+++ b/packages/core/admin/frontend/src/pages/ConfigPage.vue
@@ -56,7 +56,6 @@ const TOOLS = [
   { key: 'web_fetch', label: 'Web Fetch' },
   { key: 'web_search', label: 'Web Search' },
   { key: 'bootstrap', label: 'Bootstrap' },
-  { key: 'claude_code_mcp', label: 'Claude Code MCP' },
 ];
 
 function hydrateForm(parsed: Record<string, unknown>) {


### PR DESCRIPTION
Removes two features that won't be supported:

- **claude_code_mcp** — subagents cover the use case better; NACA-19 was marked won't fix for this reason. Closes #206.
- **firecrawl** — deferred indefinitely; default web_fetch is sufficient. Closes #205.

### Changes
- Removed `[tools.claude_code_mcp]` block from `nachos.toml.example`
- Removed `[tools.web_fetch.firecrawl]` block from `nachos.toml.example`
- Removed 'Claude Code MCP' from the admin UI tool list in `ConfigPage.vue`

### Notes
- No config schema changes needed (neither was in the validation schema)
- No gateway code changes needed (neither was wired into tool execution)