### PR TITLE
chore: fix prettier formatting on 8 docs files

### DIFF
--- a/docs/SKILL_TOOLS.md
+++ b/docs/SKILL_TOOLS.md
@@ -1,8 +1,12 @@
 # Skill Tools Reference
 
-Skills are Markdown documents (`SKILL.md`) that give Nachos specialized knowledge for external tools, APIs, and services. They are discovered automatically from the `/workspace/skills/` directory and referenced in the system prompt.
+Skills are Markdown documents (`SKILL.md`) that give Nachos specialized
+knowledge for external tools, APIs, and services. They are discovered
+automatically from the `/workspace/skills/` directory and referenced in the
+system prompt.
 
-> **Architecture note**: See [ADR-003](adr/003-skill-structure.md) for the full rationale behind the SKILL.md format.
+> **Architecture note**: See [ADR-003](adr/003-skill-structure.md) for the full
+> rationale behind the SKILL.md format.
 
 ---
 
@@ -10,42 +14,46 @@ Skills are Markdown documents (`SKILL.md`) that give Nachos specialized knowledg
 
 ### Productivity & Communication
 
-| Skill | Directory | What It Enables |
-|---|---|---|
-| `composio-gmail` | `skills/composio-gmail/` | Read, send, search, and organize Gmail via Composio |
-| `composio-gcal` | `skills/composio-gcal/` | Create, read, and manage Google Calendar events |
-| `composio-gdrive` | `skills/composio-gdrive/` | Browse, read, and upload files in Google Drive |
-| `composio-gdocs` | `skills/composio-gdocs/` | Create and edit Google Docs |
-| `composio-gmeet` | `skills/composio-gmeet/` | Schedule and manage Google Meet calls |
-| `composio-linkedin` | `skills/composio-linkedin/` | Post and read LinkedIn content (org/personal) |
-| `jira` | `skills/jira/` | Create, search, and update Jira issues and sprints |
+| Skill               | Directory                   | What It Enables                                     |
+| ------------------- | --------------------------- | --------------------------------------------------- |
+| `composio-gmail`    | `skills/composio-gmail/`    | Read, send, search, and organize Gmail via Composio |
+| `composio-gcal`     | `skills/composio-gcal/`     | Create, read, and manage Google Calendar events     |
+| `composio-gdrive`   | `skills/composio-gdrive/`   | Browse, read, and upload files in Google Drive      |
+| `composio-gdocs`    | `skills/composio-gdocs/`    | Create and edit Google Docs                         |
+| `composio-gmeet`    | `skills/composio-gmeet/`    | Schedule and manage Google Meet calls               |
+| `composio-linkedin` | `skills/composio-linkedin/` | Post and read LinkedIn content (org/personal)       |
+| `jira`              | `skills/jira/`              | Create, search, and update Jira issues and sprints  |
 
 ### Developer Tools
 
-| Skill | Directory | What It Enables |
-|---|---|---|
-| `figma` | `skills/figma/` | Fetch files, components, and design tokens from Figma |
-| `agent-browser` | `skills/agent-browser/` | Control a headless browser for web automation |
+| Skill           | Directory               | What It Enables                                       |
+| --------------- | ----------------------- | ----------------------------------------------------- |
+| `figma`         | `skills/figma/`         | Fetch files, components, and design tokens from Figma |
+| `agent-browser` | `skills/agent-browser/` | Control a headless browser for web automation         |
 
 ### Media & Data
 
-| Skill | Directory | What It Enables |
-|---|---|---|
-| `gifgrep` | `skills/gifgrep/` | Search and retrieve GIFs |
-| `gog` | `skills/gog/` | Search and retrieve information from GOG game library |
-| `goplaces` | `skills/goplaces/` | Search for places, businesses, and local info |
-| `summarize` | `skills/summarize/` | Summarize long documents or web pages |
+| Skill       | Directory           | What It Enables                                       |
+| ----------- | ------------------- | ----------------------------------------------------- |
+| `gifgrep`   | `skills/gifgrep/`   | Search and retrieve GIFs                              |
+| `gog`       | `skills/gog/`       | Search and retrieve information from GOG game library |
+| `goplaces`  | `skills/goplaces/`  | Search for places, businesses, and local info         |
+| `summarize` | `skills/summarize/` | Summarize long documents or web pages                 |
 
 ---
 
 ## How Skills Work
 
-1. At startup, Nachos scans `/workspace/skills/*/SKILL.md` and extracts names/descriptions from frontmatter.
+1. At startup, Nachos scans `/workspace/skills/*/SKILL.md` and extracts
+   names/descriptions from frontmatter.
 2. A summary of available skills is injected into the system prompt.
-3. When a skill is needed, the LLM uses the `read` tool to load the full `SKILL.md` on-demand.
-4. The skill doc provides working examples, auth details, and common error fixes.
+3. When a skill is needed, the LLM uses the `read` tool to load the full
+   `SKILL.md` on-demand.
+4. The skill doc provides working examples, auth details, and common error
+   fixes.
 
-**Skills are loaded on-demand** — only when the LLM decides it needs them. This keeps context usage low.
+**Skills are loaded on-demand** — only when the LLM decides it needs them. This
+keeps context usage low.
 
 ---
 
@@ -88,7 +96,8 @@ The skill is automatically discovered on next session start.
 
 ## Skill Format
 
-See [ADR-003](adr/003-skill-structure.md) for the full format spec. Quick reference:
+See [ADR-003](adr/003-skill-structure.md) for the full format spec. Quick
+reference:
 
 ```markdown
 ---
@@ -116,6 +125,7 @@ Brief overview.
 ```
 
 **Principles:**
+
 - Include working, copy-paste examples — not just API references
 - Show expected response structure (JSON snippets help)
 - Document common errors with fixes
@@ -125,9 +135,12 @@ Brief overview.
 
 ## Composio Skills
 
-Most external service integrations use [Composio](https://composio.dev) for auth management. Composio connection IDs are stored in the gateway config (or `TOOLS.md` in agent workspaces).
+Most external service integrations use [Composio](https://composio.dev) for auth
+management. Composio connection IDs are stored in the gateway config (or
+`TOOLS.md` in agent workspaces).
 
 To check available Composio connections:
+
 ```bash
 # Via Composio CLI
 composio apps connected
@@ -137,6 +150,9 @@ composio apps connected
 
 ## Further Reading
 
-- [ADR-003: Skill Structure](adr/003-skill-structure.md) — format rationale and design principles
-- [Architecture Overview](architecture.md) — how skills fit into the Nachos stack
-- [Creating Custom Modules](custom-modules.md) — build your own channels and tools
+- [ADR-003: Skill Structure](adr/003-skill-structure.md) — format rationale and
+  design principles
+- [Architecture Overview](architecture.md) — how skills fit into the Nachos
+  stack
+- [Creating Custom Modules](custom-modules.md) — build your own channels and
+  tools

--- a/docs/adr/005-modular-storage-backends.md
+++ b/docs/adr/005-modular-storage-backends.md
@@ -4,23 +4,27 @@
 **Date:** 2026-02-25  
 **Author:** Nachos Team
 
-> **Note:** This ADR is a stub. It was referenced by ADR-006 but not yet written. Fill in when the storage migration work begins.
+> **Note:** This ADR is a stub. It was referenced by ADR-006 but not yet
+> written. Fill in when the storage migration work begins.
 
 ## Context
 
-Nachos currently uses SQLite as the only storage backend for session state, messages, and configuration. As deployments grow, operators need options:
+Nachos currently uses SQLite as the only storage backend for session state,
+messages, and configuration. As deployments grow, operators need options:
 
 - **SQLite** — simple, zero-infra, sufficient for single-node deployments
 - **PostgreSQL** — multi-instance, production-grade, concurrent access
 - **Redis** — session caching, pub/sub for distributed message bus (future)
 
-The storage layer needs to be abstracted so backends can be swapped via config without code changes.
+The storage layer needs to be abstracted so backends can be swapped via config
+without code changes.
 
 ## Decision
 
 _[To be written]_
 
-Placeholder: implement a `StateStorage` interface that SQLite and Postgres backends satisfy. Config key: `storage.backend = "sqlite" | "postgres"`.
+Placeholder: implement a `StateStorage` interface that SQLite and Postgres
+backends satisfy. Config key: `storage.backend = "sqlite" | "postgres"`.
 
 ## Consequences
 
@@ -28,5 +32,6 @@ _[To be written]_
 
 ## References
 
-- ADR-006: Session Viewing and Continuation (references this ADR for Postgres migration path)
+- ADR-006: Session Viewing and Continuation (references this ADR for Postgres
+  migration path)
 - `packages/shared/src/storage/` (implementation location, TBD)

--- a/docs/adr/006-session-viewing-continuation.md
+++ b/docs/adr/006-session-viewing-continuation.md
@@ -1,8 +1,12 @@
 # ADR-006: Session Viewing and Continuation in Admin UI
 
-**Status:** Draft — Research stale (subagent runId `3a5fdaf8-5888-4355-bd2c-fa98247930f7` never completed; research appendix is placeholder text). Decision and implementation plan sections are still valid and should be retained for the eventual implementer. Update status to Accepted when implementation begins.
-**Date:** 2026-02-25  
-**Updated:** 2026-03-23 (ADR consolidation — marked stale research, no decision changes)  
+**Status:** Draft — Research stale (subagent runId
+`3a5fdaf8-5888-4355-bd2c-fa98247930f7` never completed; research appendix is
+placeholder text). Decision and implementation plan sections are still valid and
+should be retained for the eventual implementer. Update status to Accepted when
+implementation begins. **Date:** 2026-02-25  
+**Updated:** 2026-03-23 (ADR consolidation — marked stale research, no decision
+changes)  
 **Author:** Claw (with research subagent assistance)
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,21 +1,24 @@
 # Architectural Decision Records
 
-This directory contains ADRs (Architectural Decision Records) for Nachos. Each file documents a significant technical decision: the context, options considered, the decision made, and its consequences.
+This directory contains ADRs (Architectural Decision Records) for Nachos. Each
+file documents a significant technical decision: the context, options
+considered, the decision made, and its consequences.
 
 ## Index
 
-| # | Title | Status |
-|---|---|---|
-| [001](001-bedrock-adapter-type.md) | Bedrock Adapter Type Choice | ✅ Accepted |
-| [002](002-shell-tool-security-model.md) | Shell Tool Security Model | ✅ Accepted |
-| [003](003-skill-structure.md) | Skill Structure (SKILL.md Format) | ✅ Accepted |
-| [004](004-webchat-hybrid-rpc-architecture.md) | Webchat Hybrid RPC Architecture | 🔵 Proposed |
-| [005](005-modular-storage-backends.md) | Modular Storage Backends | 🔵 Proposed (stub) |
-| [006](006-session-viewing-continuation.md) | Session Viewing and Continuation in Admin UI | 📝 Draft (research stale) |
+| #                                             | Title                                        | Status                    |
+| --------------------------------------------- | -------------------------------------------- | ------------------------- |
+| [001](001-bedrock-adapter-type.md)            | Bedrock Adapter Type Choice                  | ✅ Accepted               |
+| [002](002-shell-tool-security-model.md)       | Shell Tool Security Model                    | ✅ Accepted               |
+| [003](003-skill-structure.md)                 | Skill Structure (SKILL.md Format)            | ✅ Accepted               |
+| [004](004-webchat-hybrid-rpc-architecture.md) | Webchat Hybrid RPC Architecture              | 🔵 Proposed               |
+| [005](005-modular-storage-backends.md)        | Modular Storage Backends                     | 🔵 Proposed (stub)        |
+| [006](006-session-viewing-continuation.md)    | Session Viewing and Continuation in Admin UI | 📝 Draft (research stale) |
 
 ## Format
 
 ADRs use a consistent structure:
+
 - **Status**: Proposed / Accepted / Deprecated / Superseded
 - **Context**: Why this decision was needed
 - **Decision**: What was decided
@@ -23,8 +26,12 @@ ADRs use a consistent structure:
 
 ## Naming Convention
 
-Files are named `NNN-short-title.md` (zero-padded 3-digit number, lowercase kebab-case title).
+Files are named `NNN-short-title.md` (zero-padded 3-digit number, lowercase
+kebab-case title).
 
 ## Previous Location
 
-ADRs 001–003 and 006 were previously in `docs/architecture/decisions/`. Consolidated here on 2026-03-23 for consistent naming and discoverability. The `docs/architecture/decisions/` directory is now deprecated — do not add new ADRs there.
+ADRs 001–003 and 006 were previously in `docs/architecture/decisions/`.
+Consolidated here on 2026-03-23 for consistent naming and discoverability. The
+`docs/architecture/decisions/` directory is now deprecated — do not add new ADRs
+there.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,16 @@
 # Architecture Deep Dive
 
-This document describes how Nachos is structured internally. For high-level concepts, see the [README](../README.md). For specific decisions and their rationale, see the [ADRs](adr/).
+This document describes how Nachos is structured internally. For high-level
+concepts, see the [README](../README.md). For specific decisions and their
+rationale, see the [ADRs](adr/).
 
 ---
 
 ## Overview
 
-Nachos is a monorepo of Docker-native packages that together form a self-hosted AI assistant platform. The core concern is routing: messages from channels → gateway → LLM → tools → back to channel.
+Nachos is a monorepo of Docker-native packages that together form a self-hosted
+AI assistant platform. The core concern is routing: messages from channels →
+gateway → LLM → tools → back to channel.
 
 ```
 ┌──────────────────────────────────────────────────────┐
@@ -46,22 +50,22 @@ Nachos is a monorepo of Docker-native packages that together form a self-hosted 
 
 ## Package Map
 
-| Package | Path | Role |
-|---|---|---|
-| `gateway` | `packages/core/gateway` | Central orchestrator. Routes messages, manages sessions, dispatches tools. |
-| `bus` | `packages/bus` | Internal message bus. Channels and gateway communicate via events. |
-| `llm-proxy` | `packages/core/llm-proxy` | Adapter layer for LLM providers (Anthropic, OpenAI, Bedrock, Ollama). |
-| `admin` | `packages/admin` | Vue.js admin UI. Config editor, session viewer, log tailing. |
-| `cli` | `packages/cli` | `nachos` CLI. `nachos init`, `nachos up`, `nachos config`. |
-| `shared` | `packages/shared` | Shared types, config schema, validation, utilities. |
-| `channels/discord` | `packages/channels/discord` | Discord adapter. |
-| `channels/slack` | `packages/channels/slack` | Slack adapter. |
-| `channels/telegram` | `packages/channels/telegram` | Telegram adapter. |
-| `channels/whatsapp` | `packages/channels/whatsapp` | WhatsApp adapter. |
-| `channels/matrix` | `packages/channels/matrix` | Matrix/Element adapter. |
-| `tools/filesystem` | `packages/tools/filesystem` | File read/write tool. |
-| `tools/web-fetch` | `packages/tools/web-fetch` | HTTP fetch / web scraping tool. |
-| `tools/code-runner` | `packages/tools/code-runner` | Sandboxed code execution. |
+| Package             | Path                         | Role                                                                       |
+| ------------------- | ---------------------------- | -------------------------------------------------------------------------- |
+| `gateway`           | `packages/core/gateway`      | Central orchestrator. Routes messages, manages sessions, dispatches tools. |
+| `bus`               | `packages/bus`               | Internal message bus. Channels and gateway communicate via events.         |
+| `llm-proxy`         | `packages/core/llm-proxy`    | Adapter layer for LLM providers (Anthropic, OpenAI, Bedrock, Ollama).      |
+| `admin`             | `packages/admin`             | Vue.js admin UI. Config editor, session viewer, log tailing.               |
+| `cli`               | `packages/cli`               | `nachos` CLI. `nachos init`, `nachos up`, `nachos config`.                 |
+| `shared`            | `packages/shared`            | Shared types, config schema, validation, utilities.                        |
+| `channels/discord`  | `packages/channels/discord`  | Discord adapter.                                                           |
+| `channels/slack`    | `packages/channels/slack`    | Slack adapter.                                                             |
+| `channels/telegram` | `packages/channels/telegram` | Telegram adapter.                                                          |
+| `channels/whatsapp` | `packages/channels/whatsapp` | WhatsApp adapter.                                                          |
+| `channels/matrix`   | `packages/channels/matrix`   | Matrix/Element adapter.                                                    |
+| `tools/filesystem`  | `packages/tools/filesystem`  | File read/write tool.                                                      |
+| `tools/web-fetch`   | `packages/tools/web-fetch`   | HTTP fetch / web scraping tool.                                            |
+| `tools/code-runner` | `packages/tools/code-runner` | Sandboxed code execution.                                                  |
 
 ---
 
@@ -70,14 +74,19 @@ Nachos is a monorepo of Docker-native packages that together form a self-hosted 
 The gateway is the brain. On message receipt:
 
 1. **Session lookup / creation** — each conversation gets a persistent session
-2. **Prompt assembly** — system prompt + tool definitions + message history assembled (see [BOOTSTRAP_PROMPT_ASSEMBLY.md](BOOTSTRAP_PROMPT_ASSEMBLY.md))
+2. **Prompt assembly** — system prompt + tool definitions + message history
+   assembled (see [BOOTSTRAP_PROMPT_ASSEMBLY.md](BOOTSTRAP_PROMPT_ASSEMBLY.md))
 3. **LLM dispatch** — request sent to configured LLM provider via llm-proxy
-4. **Tool handling** — if the LLM requests a tool call, gateway dispatches, collects result, re-enters LLM loop
-5. **Response delivery** — final response delivered back through the originating channel
+4. **Tool handling** — if the LLM requests a tool call, gateway dispatches,
+   collects result, re-enters LLM loop
+5. **Response delivery** — final response delivered back through the originating
+   channel
 
 ### Session Management
 
-Sessions are stored in StateStorage (SQLite by default, Postgres supported). Each session holds:
+Sessions are stored in StateStorage (SQLite by default, Postgres supported).
+Each session holds:
+
 - Conversation history (messages)
 - Session metadata (channel, user, status)
 - Configuration overrides
@@ -86,13 +95,16 @@ See `packages/core/gateway/src/session/` for implementation.
 
 ### Security Enforcement
 
-Security mode is applied at the gateway layer — before any tool is dispatched. See [Security Guide](security.md) and [ADR-002](adr/002-shell-tool-security-model.md).
+Security mode is applied at the gateway layer — before any tool is dispatched.
+See [Security Guide](security.md) and
+[ADR-002](adr/002-shell-tool-security-model.md).
 
 ---
 
 ## LLM Proxy
 
-The LLM proxy normalizes differences between providers into a single interface. All providers implement:
+The LLM proxy normalizes differences between providers into a single interface.
+All providers implement:
 
 ```typescript
 interface LLMProvider {
@@ -101,15 +113,19 @@ interface LLMProvider {
 }
 ```
 
-Provider selection is by `llm.provider` in config. See [ADR-001](adr/001-bedrock-adapter-type.md) for the Bedrock adapter decision.
+Provider selection is by `llm.provider` in config. See
+[ADR-001](adr/001-bedrock-adapter-type.md) for the Bedrock adapter decision.
 
 ---
 
 ## Message Bus
 
-The bus decouples channels from the gateway. Channels publish `message.received` events; the gateway subscribes and processes them. Responses are published back as `message.send` events.
+The bus decouples channels from the gateway. Channels publish `message.received`
+events; the gateway subscribes and processes them. Responses are published back
+as `message.send` events.
 
 This enables:
+
 - Hot-pluggable channels (add/remove without restarting gateway)
 - Future horizontal scaling (multiple gateway replicas)
 
@@ -117,21 +133,28 @@ This enables:
 
 ## Skills
 
-Skills are Markdown documents (`SKILL.md`) that provide the LLM with specialized knowledge for external tools and APIs. They are injected into the system prompt at startup.
+Skills are Markdown documents (`SKILL.md`) that provide the LLM with specialized
+knowledge for external tools and APIs. They are injected into the system prompt
+at startup.
 
-See [ADR-003](adr/003-skill-structure.md) for the skill format decision, and [SKILL_TOOLS.md](SKILL_TOOLS.md) for the catalog of available skills.
+See [ADR-003](adr/003-skill-structure.md) for the skill format decision, and
+[SKILL_TOOLS.md](SKILL_TOOLS.md) for the catalog of available skills.
 
 ---
 
 ## Configuration
 
-All configuration is in `nachos.toml`. Types are defined in `packages/shared/config/src/schema.ts` and validated at startup. See [Configuration Reference](configuration.md).
+All configuration is in `nachos.toml`. Types are defined in
+`packages/shared/config/src/schema.ts` and validated at startup. See
+[Configuration Reference](configuration.md).
 
 ---
 
 ## Further Reading
 
-- [Bootstrap Prompt Assembly](BOOTSTRAP_PROMPT_ASSEMBLY.md) — how the system prompt is constructed
-- [Subagent Orchestration](SUBAGENT_ORCHESTRATION.md) — how Nachos spawns and manages sub-agents
+- [Bootstrap Prompt Assembly](BOOTSTRAP_PROMPT_ASSEMBLY.md) — how the system
+  prompt is constructed
+- [Subagent Orchestration](SUBAGENT_ORCHESTRATION.md) — how Nachos spawns and
+  manages sub-agents
 - [ADRs](adr/) — all architectural decisions with rationale
 - [Guides](guides/) — deep dives on specific subsystems

--- a/docs/custom-modules.md
+++ b/docs/custom-modules.md
@@ -1,6 +1,7 @@
 # Creating Custom Modules
 
-Nachos is built to be extended. This guide covers adding your own channels, tools, and skills.
+Nachos is built to be extended. This guide covers adding your own channels,
+tools, and skills.
 
 ---
 
@@ -8,13 +9,14 @@ Nachos is built to be extended. This guide covers adding your own channels, tool
 
 There are three extension points:
 
-| Type | What It Does | Where It Lives |
-|---|---|---|
-| **Channel** | Connect Nachos to a messaging platform | `packages/channels/<name>/` |
-| **Tool** | Let Nachos take actions (run code, call APIs, etc.) | `packages/tools/<name>/` |
-| **Skill** | Give Nachos knowledge for an external service | `workspace/skills/<name>/SKILL.md` |
+| Type        | What It Does                                        | Where It Lives                     |
+| ----------- | --------------------------------------------------- | ---------------------------------- |
+| **Channel** | Connect Nachos to a messaging platform              | `packages/channels/<name>/`        |
+| **Tool**    | Let Nachos take actions (run code, call APIs, etc.) | `packages/tools/<name>/`           |
+| **Skill**   | Give Nachos knowledge for an external service       | `workspace/skills/<name>/SKILL.md` |
 
-Skills are the easiest — just a Markdown file, no code required. Channels and tools require TypeScript packages.
+Skills are the easiest — just a Markdown file, no code required. Channels and
+tools require TypeScript packages.
 
 ---
 
@@ -40,37 +42,33 @@ Brief description of what this skill enables.
 
 ## Authentication
 
-\`\`\`bash
-export MY_SERVICE_API_KEY="your-key-here"
-\`\`\`
+\`\`\`bash export MY_SERVICE_API_KEY="your-key-here" \`\`\`
 
 ## Common Operations
 
 ### List items
 
-\`\`\`bash
-curl -H "Authorization: Bearer $MY_SERVICE_API_KEY" \
-     https://api.myservice.com/v1/items
-\`\`\`
+\`\`\`bash curl -H "Authorization: Bearer $MY_SERVICE_API_KEY" \
+ https://api.myservice.com/v1/items \`\`\`
 
-Expected response:
-\`\`\`json
-{"items": [...], "total": 42}
-\`\`\`
+Expected response: \`\`\`json {"items": [...], "total": 42} \`\`\`
 
 ## Troubleshooting
 
-**401 Unauthorized** — Check your API key is set and valid.
-**404 Not Found** — The resource ID doesn't exist or you don't have access.
+**401 Unauthorized** — Check your API key is set and valid. **404 Not Found** —
+The resource ID doesn't exist or you don't have access.
 ```
 
-Skills are auto-discovered on next session start. See [SKILL_TOOLS.md](SKILL_TOOLS.md) for the full catalog and [ADR-003](adr/003-skill-structure.md) for format details.
+Skills are auto-discovered on next session start. See
+[SKILL_TOOLS.md](SKILL_TOOLS.md) for the full catalog and
+[ADR-003](adr/003-skill-structure.md) for format details.
 
 ---
 
 ## 2. Adding a Tool (Medium)
 
-Tools let Nachos take programmatic actions. They are TypeScript packages in `packages/tools/`.
+Tools let Nachos take programmatic actions. They are TypeScript packages in
+`packages/tools/`.
 
 ### Scaffold
 
@@ -81,6 +79,7 @@ cd packages/tools/my-tool
 ```
 
 Update `package.json`:
+
 ```json
 {
   "name": "@nachos/tool-my-tool",
@@ -92,7 +91,12 @@ Update `package.json`:
 
 ```typescript
 // src/index.ts
-import type { NachosTool, ToolDefinition, ToolContext, ToolResult } from '@nachos/shared';
+import type {
+  NachosTool,
+  ToolDefinition,
+  ToolContext,
+  ToolResult,
+} from '@nachos/shared';
 
 export class MyTool implements NachosTool {
   readonly name = 'my-tool';
@@ -150,7 +154,8 @@ type = "my-tool"
 
 ## 3. Adding a Channel (Advanced)
 
-Channels connect Nachos to messaging platforms. They publish and subscribe to the message bus.
+Channels connect Nachos to messaging platforms. They publish and subscribe to
+the message bus.
 
 ### Scaffold
 
@@ -163,7 +168,11 @@ cd packages/channels/my-channel
 
 ```typescript
 // src/index.ts
-import type { NachosChannel, InboundMessage, OutboundMessage } from '@nachos/shared';
+import type {
+  NachosChannel,
+  InboundMessage,
+  OutboundMessage,
+} from '@nachos/shared';
 
 export class MyChannel implements NachosChannel {
   readonly name = 'my-channel';
@@ -213,16 +222,24 @@ pnpm test
 
 ## Tips
 
-- **Start with a skill** — if you just need to call an API, a skill is almost always enough. Save tool/channel work for things that genuinely need programmatic integration.
-- **Look at existing packages** — `packages/tools/web-fetch` is a good minimal tool example; `packages/channels/discord` is the most complete channel example.
-- **Security**: Tools run with the security mode of the gateway. If your tool does sensitive operations, document it clearly and test with `strict` mode.
-- **Error handling**: Return descriptive errors from `execute()`. The LLM uses your error messages to self-correct.
+- **Start with a skill** — if you just need to call an API, a skill is almost
+  always enough. Save tool/channel work for things that genuinely need
+  programmatic integration.
+- **Look at existing packages** — `packages/tools/web-fetch` is a good minimal
+  tool example; `packages/channels/discord` is the most complete channel
+  example.
+- **Security**: Tools run with the security mode of the gateway. If your tool
+  does sensitive operations, document it clearly and test with `strict` mode.
+- **Error handling**: Return descriptive errors from `execute()`. The LLM uses
+  your error messages to self-correct.
 
 ---
 
 ## Further Reading
 
 - [SKILL_TOOLS.md](SKILL_TOOLS.md) — catalog of existing skills
-- [ADR-003: Skill Structure](adr/003-skill-structure.md) — skill format rationale
-- [Architecture Overview](architecture.md) — how channels, tools, and gateway connect
+- [ADR-003: Skill Structure](adr/003-skill-structure.md) — skill format
+  rationale
+- [Architecture Overview](architecture.md) — how channels, tools, and gateway
+  connect
 - [Security Guide](security.md) — security model and tool permissions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,12 +1,14 @@
 # Getting Started with Nachos
 
-Welcome to Nachos — your AI assistant, your way. This guide walks you from zero to a running instance in minutes.
+Welcome to Nachos — your AI assistant, your way. This guide walks you from zero
+to a running instance in minutes.
 
 ---
 
 ## Prerequisites
 
-- [Docker Desktop](https://docs.docker.com/get-docker/) (Mac/Windows) or Docker Engine + Compose plugin (Linux)
+- [Docker Desktop](https://docs.docker.com/get-docker/) (Mac/Windows) or Docker
+  Engine + Compose plugin (Linux)
 - An LLM API key (Anthropic, OpenAI, or a local Ollama instance)
 
 ---
@@ -26,7 +28,8 @@ cp .env.example .env
 docker compose up
 ```
 
-Open [http://localhost:8080](http://localhost:8080) to see the web chat interface.
+Open [http://localhost:8080](http://localhost:8080) to see the web chat
+interface.
 
 ---
 
@@ -60,13 +63,15 @@ type = "discord"
 token = "${DISCORD_TOKEN}"
 ```
 
-Set `DISCORD_TOKEN` in your `.env`. See [Skill Tools](SKILL_TOOLS.md) for available channel skills.
+Set `DISCORD_TOKEN` in your `.env`. See [Skill Tools](SKILL_TOOLS.md) for
+available channel skills.
 
 ---
 
 ## 4. Add Tools
 
-Tools let Nachos take actions (browse the web, run shell commands, read files). Example:
+Tools let Nachos take actions (browse the web, run shell commands, read files).
+Example:
 
 ```toml
 [[tools]]
@@ -97,21 +102,24 @@ docker compose -f docker-compose.dev.yml logs -f gateway
 
 - [Configuration Reference](configuration.md) — complete option reference
 - [Security Guide](security.md) — understand security modes and best practices
-- [Architecture Deep Dive](architecture.md) — how Nachos is structured internally
-- [Creating Custom Modules](custom-modules.md) — extend Nachos with your own channels and tools
+- [Architecture Deep Dive](architecture.md) — how Nachos is structured
+  internally
+- [Creating Custom Modules](custom-modules.md) — extend Nachos with your own
+  channels and tools
 - [ADRs](adr/) — architectural decisions and their rationale
 
 ---
 
 ## Troubleshooting
 
-**Container won't start:**
-Check that your `.env` has a valid API key and `nachos.toml` is present. Run `docker compose logs gateway` for details.
+**Container won't start:** Check that your `.env` has a valid API key and
+`nachos.toml` is present. Run `docker compose logs gateway` for details.
 
-**Web chat not loading:**
-Verify port 8080 is free. If using a custom port, check the `webui.port` config option.
+**Web chat not loading:** Verify port 8080 is free. If using a custom port,
+check the `webui.port` config option.
 
-**LLM errors / 401 Unauthorized:**
-Your API key is invalid or missing. Double-check `.env` and restart the stack.
+**LLM errors / 401 Unauthorized:** Your API key is invalid or missing.
+Double-check `.env` and restart the stack.
 
-For more help, see the [full troubleshooting guide](TROUBLESHOOTING.md) (coming soon) or open a GitHub issue.
+For more help, see the [full troubleshooting guide](TROUBLESHOOTING.md) (coming
+soon) or open a GitHub issue.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,7 @@
 # Security Guide
 
-Nachos is designed with security-first defaults. This guide explains the security model, available modes, and best practices for safe deployment.
+Nachos is designed with security-first defaults. This guide explains the
+security model, available modes, and best practices for safe deployment.
 
 ---
 
@@ -9,17 +10,20 @@ Nachos is designed with security-first defaults. This guide explains the securit
 Nachos has three security modes, set via `security.mode` in `nachos.toml`:
 
 ### `strict` (default)
+
 - Only allowlisted tools enabled
 - No shell access
 - Pairing required for DMs
 - Recommended for production
 
 ### `standard`
+
 - Common tools enabled (file inspection, network debugging, git read)
 - Pairing-based DMs
 - Balanced security for trusted environments
 
 ### `permissive`
+
 - All tools available, including shell
 - Use only in air-gapped or fully trusted environments
 
@@ -32,17 +36,21 @@ mode = "standard"  # strict | standard | permissive
 
 ## Shell Tool Security
 
-When the shell tool is enabled (`mode = "permissive"` or explicit config), Nachos enforces:
+When the shell tool is enabled (`mode = "permissive"` or explicit config),
+Nachos enforces:
 
 1. **Binary allowlist** — only registered binaries can be executed
-2. **Direct process spawning** — no shell interpreter, eliminating injection attacks
+2. **Direct process spawning** — no shell interpreter, eliminating injection
+   attacks
 3. **Subcommand filtering** — e.g., `git status` is allowed, `git push` is not
 4. **Resource limits** — 30s timeout (configurable, max 5min), 100KB output cap
-5. **Audit logging** — all executions logged to `/var/log/nachos/shell-audit.log`
+5. **Audit logging** — all executions logged to
+   `/var/log/nachos/shell-audit.log`
 
 See [ADR-002](adr/002-shell-tool-security-model.md) for the full rationale.
 
 **What's blocked by default:**
+
 - Destructive ops: `rm`, `mv`, `chmod`, `chown`
 - Shell execution: `bash`, `sh`, `eval`
 - Package managers: `npm install`, `apt-get`, `pip`
@@ -52,23 +60,28 @@ See [ADR-002](adr/002-shell-tool-security-model.md) for the full rationale.
 
 ## Network Isolation
 
-Nachos runs in an isolated Docker network by default. Containers cannot reach each other unless explicitly linked. The gateway is the only externally-exposed service.
+Nachos runs in an isolated Docker network by default. Containers cannot reach
+each other unless explicitly linked. The gateway is the only externally-exposed
+service.
 
 ```yaml
 # docker-compose.yml (enforced)
 networks:
   nachos-internal:
-    internal: true  # no external routing
+    internal: true # no external routing
 ```
 
-To allow outbound access (e.g., for web browsing tools), set `security.mode = "standard"` or add explicit network policies.
+To allow outbound access (e.g., for web browsing tools), set
+`security.mode = "standard"` or add explicit network policies.
 
 ---
 
 ## Credential Handling
 
 **Rules:**
-- Never put API keys or tokens in `nachos.toml`. Use `.env` or environment variables.
+
+- Never put API keys or tokens in `nachos.toml`. Use `.env` or environment
+  variables.
 - `.env` is in `.gitignore` — do not commit it.
 - Tokens referenced as `${ENV_VAR}` in config are resolved at startup.
 
@@ -88,7 +101,8 @@ token = "MTAzN..."  # Never do this
 
 ## Pairing and DMs
 
-Direct Messages to the bot are gated by the pairing system. A user must complete a pairing handshake before they can send private messages.
+Direct Messages to the bot are gated by the pairing system. A user must complete
+a pairing handshake before they can send private messages.
 
 - `security.mode = "strict"`: Pairing always required for DMs
 - `security.mode = "standard"`: Pairing required for DMs (same)
@@ -100,11 +114,11 @@ Direct Messages to the bot are gated by the pairing system. A user must complete
 
 All tool executions and config changes are logged. Log locations:
 
-| Event | Log path |
-|---|---|
-| Shell commands | `/var/log/nachos/shell-audit.log` |
+| Event          | Log path                                    |
+| -------------- | ------------------------------------------- |
+| Shell commands | `/var/log/nachos/shell-audit.log`           |
 | Gateway events | Docker logs (`docker compose logs gateway`) |
-| Config loads | Gateway startup logs |
+| Config loads   | Gateway startup logs                        |
 
 ---
 
@@ -121,7 +135,8 @@ All tool executions and config changes are logged. Log locations:
 
 ## Reporting Vulnerabilities
 
-Please do not open public GitHub issues for security vulnerabilities. Email the maintainers directly or use GitHub's private security advisory feature.
+Please do not open public GitHub issues for security vulnerabilities. Email the
+maintainers directly or use GitHub's private security advisory feature.
 
 ---
 


### PR DESCRIPTION
## What

Fixes prettier formatting violations on 8 docs files. Formatting-only, zero content changes.

## Why

These files were causing the `Lint` CI job (specifically `pnpm format:check`) to fail on PR #209. Because CI runs against the merge commit (branch + main), pre-existing formatting failures on `main` bleed into otherwise-clean PRs.

### Files fixed
- `docs/adr/005-modular-storage-backends.md`
- `docs/adr/006-session-viewing-continuation.md`
- `docs/adr/README.md`
- `docs/architecture.md`
- `docs/custom-modules.md`
- `docs/getting-started.md`
- `docs/security.md`
- `docs/SKILL_TOOLS.md`

## How

```
pnpm prettier --write <files>
```

## Testing

`pnpm format:check` now passes cleanly on main after this merge.

Merging this will unblock the CI Lint failure on PR #209 (`feat(cli): add nachos migrate command`).