### PR TITLE
feat(bootstrap): improve default onboarding + nachos.toml bootstrap_prompt config

### DIFF
--- a/docs/SKILL_TOOLS.md
+++ b/docs/SKILL_TOOLS.md
@@ -1,8 +1,12 @@
 # Skill Tools Reference
 
-Skills are Markdown documents (`SKILL.md`) that give Nachos specialized knowledge for external tools, APIs, and services. They are discovered automatically from the `/workspace/skills/` directory and referenced in the system prompt.
+Skills are Markdown documents (`SKILL.md`) that give Nachos specialized
+knowledge for external tools, APIs, and services. They are discovered
+automatically from the `/workspace/skills/` directory and referenced in the
+system prompt.
 
-> **Architecture note**: See [ADR-003](adr/003-skill-structure.md) for the full rationale behind the SKILL.md format.
+> **Architecture note**: See [ADR-003](adr/003-skill-structure.md) for the full
+> rationale behind the SKILL.md format.
 
 ---
 
@@ -10,42 +14,46 @@ Skills are Markdown documents (`SKILL.md`) that give Nachos specialized knowledg
 
 ### Productivity & Communication
 
-| Skill | Directory | What It Enables |
-|---|---|---|
-| `composio-gmail` | `skills/composio-gmail/` | Read, send, search, and organize Gmail via Composio |
-| `composio-gcal` | `skills/composio-gcal/` | Create, read, and manage Google Calendar events |
-| `composio-gdrive` | `skills/composio-gdrive/` | Browse, read, and upload files in Google Drive |
-| `composio-gdocs` | `skills/composio-gdocs/` | Create and edit Google Docs |
-| `composio-gmeet` | `skills/composio-gmeet/` | Schedule and manage Google Meet calls |
-| `composio-linkedin` | `skills/composio-linkedin/` | Post and read LinkedIn content (org/personal) |
-| `jira` | `skills/jira/` | Create, search, and update Jira issues and sprints |
+| Skill               | Directory                   | What It Enables                                     |
+| ------------------- | --------------------------- | --------------------------------------------------- |
+| `composio-gmail`    | `skills/composio-gmail/`    | Read, send, search, and organize Gmail via Composio |
+| `composio-gcal`     | `skills/composio-gcal/`     | Create, read, and manage Google Calendar events     |
+| `composio-gdrive`   | `skills/composio-gdrive/`   | Browse, read, and upload files in Google Drive      |
+| `composio-gdocs`    | `skills/composio-gdocs/`    | Create and edit Google Docs                         |
+| `composio-gmeet`    | `skills/composio-gmeet/`    | Schedule and manage Google Meet calls               |
+| `composio-linkedin` | `skills/composio-linkedin/` | Post and read LinkedIn content (org/personal)       |
+| `jira`              | `skills/jira/`              | Create, search, and update Jira issues and sprints  |
 
 ### Developer Tools
 
-| Skill | Directory | What It Enables |
-|---|---|---|
-| `figma` | `skills/figma/` | Fetch files, components, and design tokens from Figma |
-| `agent-browser` | `skills/agent-browser/` | Control a headless browser for web automation |
+| Skill           | Directory               | What It Enables                                       |
+| --------------- | ----------------------- | ----------------------------------------------------- |
+| `figma`         | `skills/figma/`         | Fetch files, components, and design tokens from Figma |
+| `agent-browser` | `skills/agent-browser/` | Control a headless browser for web automation         |
 
 ### Media & Data
 
-| Skill | Directory | What It Enables |
-|---|---|---|
-| `gifgrep` | `skills/gifgrep/` | Search and retrieve GIFs |
-| `gog` | `skills/gog/` | Search and retrieve information from GOG game library |
-| `goplaces` | `skills/goplaces/` | Search for places, businesses, and local info |
-| `summarize` | `skills/summarize/` | Summarize long documents or web pages |
+| Skill       | Directory           | What It Enables                                       |
+| ----------- | ------------------- | ----------------------------------------------------- |
+| `gifgrep`   | `skills/gifgrep/`   | Search and retrieve GIFs                              |
+| `gog`       | `skills/gog/`       | Search and retrieve information from GOG game library |
+| `goplaces`  | `skills/goplaces/`  | Search for places, businesses, and local info         |
+| `summarize` | `skills/summarize/` | Summarize long documents or web pages                 |
 
 ---
 
 ## How Skills Work
 
-1. At startup, Nachos scans `/workspace/skills/*/SKILL.md` and extracts names/descriptions from frontmatter.
+1. At startup, Nachos scans `/workspace/skills/*/SKILL.md` and extracts
+   names/descriptions from frontmatter.
 2. A summary of available skills is injected into the system prompt.
-3. When a skill is needed, the LLM uses the `read` tool to load the full `SKILL.md` on-demand.
-4. The skill doc provides working examples, auth details, and common error fixes.
+3. When a skill is needed, the LLM uses the `read` tool to load the full
+   `SKILL.md` on-demand.
+4. The skill doc provides working examples, auth details, and common error
+   fixes.
 
-**Skills are loaded on-demand** — only when the LLM decides it needs them. This keeps context usage low.
+**Skills are loaded on-demand** — only when the LLM decides it needs them. This
+keeps context usage low.
 
 ---
 
@@ -88,7 +96,8 @@ The skill is automatically discovered on next session start.
 
 ## Skill Format
 
-See [ADR-003](adr/003-skill-structure.md) for the full format spec. Quick reference:
+See [ADR-003](adr/003-skill-structure.md) for the full format spec. Quick
+reference:
 
 ```markdown
 ---
@@ -116,6 +125,7 @@ Brief overview.
 ```
 
 **Principles:**
+
 - Include working, copy-paste examples — not just API references
 - Show expected response structure (JSON snippets help)
 - Document common errors with fixes
@@ -125,9 +135,12 @@ Brief overview.
 
 ## Composio Skills
 
-Most external service integrations use [Composio](https://composio.dev) for auth management. Composio connection IDs are stored in the gateway config (or `TOOLS.md` in agent workspaces).
+Most external service integrations use [Composio](https://composio.dev) for auth
+management. Composio connection IDs are stored in the gateway config (or
+`TOOLS.md` in agent workspaces).
 
 To check available Composio connections:
+
 ```bash
 # Via Composio CLI
 composio apps connected
@@ -137,6 +150,9 @@ composio apps connected
 
 ## Further Reading
 
-- [ADR-003: Skill Structure](adr/003-skill-structure.md) — format rationale and design principles
-- [Architecture Overview](architecture.md) — how skills fit into the Nachos stack
-- [Creating Custom Modules](custom-modules.md) — build your own channels and tools
+- [ADR-003: Skill Structure](adr/003-skill-structure.md) — format rationale and
+  design principles
+- [Architecture Overview](architecture.md) — how skills fit into the Nachos
+  stack
+- [Creating Custom Modules](custom-modules.md) — build your own channels and
+  tools

--- a/docs/adr/005-modular-storage-backends.md
+++ b/docs/adr/005-modular-storage-backends.md
@@ -4,23 +4,27 @@
 **Date:** 2026-02-25  
 **Author:** Nachos Team
 
-> **Note:** This ADR is a stub. It was referenced by ADR-006 but not yet written. Fill in when the storage migration work begins.
+> **Note:** This ADR is a stub. It was referenced by ADR-006 but not yet
+> written. Fill in when the storage migration work begins.
 
 ## Context
 
-Nachos currently uses SQLite as the only storage backend for session state, messages, and configuration. As deployments grow, operators need options:
+Nachos currently uses SQLite as the only storage backend for session state,
+messages, and configuration. As deployments grow, operators need options:
 
 - **SQLite** — simple, zero-infra, sufficient for single-node deployments
 - **PostgreSQL** — multi-instance, production-grade, concurrent access
 - **Redis** — session caching, pub/sub for distributed message bus (future)
 
-The storage layer needs to be abstracted so backends can be swapped via config without code changes.
+The storage layer needs to be abstracted so backends can be swapped via config
+without code changes.
 
 ## Decision
 
 _[To be written]_
 
-Placeholder: implement a `StateStorage` interface that SQLite and Postgres backends satisfy. Config key: `storage.backend = "sqlite" | "postgres"`.
+Placeholder: implement a `StateStorage` interface that SQLite and Postgres
+backends satisfy. Config key: `storage.backend = "sqlite" | "postgres"`.
 
 ## Consequences
 
@@ -28,5 +32,6 @@ _[To be written]_
 
 ## References
 
-- ADR-006: Session Viewing and Continuation (references this ADR for Postgres migration path)
+- ADR-006: Session Viewing and Continuation (references this ADR for Postgres
+  migration path)
 - `packages/shared/src/storage/` (implementation location, TBD)

--- a/docs/adr/006-session-viewing-continuation.md
+++ b/docs/adr/006-session-viewing-continuation.md
@@ -1,8 +1,12 @@
 # ADR-006: Session Viewing and Continuation in Admin UI
 
-**Status:** Draft — Research stale (subagent runId `3a5fdaf8-5888-4355-bd2c-fa98247930f7` never completed; research appendix is placeholder text). Decision and implementation plan sections are still valid and should be retained for the eventual implementer. Update status to Accepted when implementation begins.
-**Date:** 2026-02-25  
-**Updated:** 2026-03-23 (ADR consolidation — marked stale research, no decision changes)  
+**Status:** Draft — Research stale (subagent runId
+`3a5fdaf8-5888-4355-bd2c-fa98247930f7` never completed; research appendix is
+placeholder text). Decision and implementation plan sections are still valid and
+should be retained for the eventual implementer. Update status to Accepted when
+implementation begins. **Date:** 2026-02-25  
+**Updated:** 2026-03-23 (ADR consolidation — marked stale research, no decision
+changes)  
 **Author:** Claw (with research subagent assistance)
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,21 +1,24 @@
 # Architectural Decision Records
 
-This directory contains ADRs (Architectural Decision Records) for Nachos. Each file documents a significant technical decision: the context, options considered, the decision made, and its consequences.
+This directory contains ADRs (Architectural Decision Records) for Nachos. Each
+file documents a significant technical decision: the context, options
+considered, the decision made, and its consequences.
 
 ## Index
 
-| # | Title | Status |
-|---|---|---|
-| [001](001-bedrock-adapter-type.md) | Bedrock Adapter Type Choice | ✅ Accepted |
-| [002](002-shell-tool-security-model.md) | Shell Tool Security Model | ✅ Accepted |
-| [003](003-skill-structure.md) | Skill Structure (SKILL.md Format) | ✅ Accepted |
-| [004](004-webchat-hybrid-rpc-architecture.md) | Webchat Hybrid RPC Architecture | 🔵 Proposed |
-| [005](005-modular-storage-backends.md) | Modular Storage Backends | 🔵 Proposed (stub) |
-| [006](006-session-viewing-continuation.md) | Session Viewing and Continuation in Admin UI | 📝 Draft (research stale) |
+| #                                             | Title                                        | Status                    |
+| --------------------------------------------- | -------------------------------------------- | ------------------------- |
+| [001](001-bedrock-adapter-type.md)            | Bedrock Adapter Type Choice                  | ✅ Accepted               |
+| [002](002-shell-tool-security-model.md)       | Shell Tool Security Model                    | ✅ Accepted               |
+| [003](003-skill-structure.md)                 | Skill Structure (SKILL.md Format)            | ✅ Accepted               |
+| [004](004-webchat-hybrid-rpc-architecture.md) | Webchat Hybrid RPC Architecture              | 🔵 Proposed               |
+| [005](005-modular-storage-backends.md)        | Modular Storage Backends                     | 🔵 Proposed (stub)        |
+| [006](006-session-viewing-continuation.md)    | Session Viewing and Continuation in Admin UI | 📝 Draft (research stale) |
 
 ## Format
 
 ADRs use a consistent structure:
+
 - **Status**: Proposed / Accepted / Deprecated / Superseded
 - **Context**: Why this decision was needed
 - **Decision**: What was decided
@@ -23,8 +26,12 @@ ADRs use a consistent structure:
 
 ## Naming Convention
 
-Files are named `NNN-short-title.md` (zero-padded 3-digit number, lowercase kebab-case title).
+Files are named `NNN-short-title.md` (zero-padded 3-digit number, lowercase
+kebab-case title).
 
 ## Previous Location
 
-ADRs 001–003 and 006 were previously in `docs/architecture/decisions/`. Consolidated here on 2026-03-23 for consistent naming and discoverability. The `docs/architecture/decisions/` directory is now deprecated — do not add new ADRs there.
+ADRs 001–003 and 006 were previously in `docs/architecture/decisions/`.
+Consolidated here on 2026-03-23 for consistent naming and discoverability. The
+`docs/architecture/decisions/` directory is now deprecated — do not add new ADRs
+there.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,16 @@
 # Architecture Deep Dive
 
-This document describes how Nachos is structured internally. For high-level concepts, see the [README](../README.md). For specific decisions and their rationale, see the [ADRs](adr/).
+This document describes how Nachos is structured internally. For high-level
+concepts, see the [README](../README.md). For specific decisions and their
+rationale, see the [ADRs](adr/).
 
 ---
 
 ## Overview
 
-Nachos is a monorepo of Docker-native packages that together form a self-hosted AI assistant platform. The core concern is routing: messages from channels → gateway → LLM → tools → back to channel.
+Nachos is a monorepo of Docker-native packages that together form a self-hosted
+AI assistant platform. The core concern is routing: messages from channels →
+gateway → LLM → tools → back to channel.
 
 ```
 ┌──────────────────────────────────────────────────────┐
@@ -46,22 +50,22 @@ Nachos is a monorepo of Docker-native packages that together form a self-hosted 
 
 ## Package Map
 
-| Package | Path | Role |
-|---|---|---|
-| `gateway` | `packages/core/gateway` | Central orchestrator. Routes messages, manages sessions, dispatches tools. |
-| `bus` | `packages/bus` | Internal message bus. Channels and gateway communicate via events. |
-| `llm-proxy` | `packages/core/llm-proxy` | Adapter layer for LLM providers (Anthropic, OpenAI, Bedrock, Ollama). |
-| `admin` | `packages/admin` | Vue.js admin UI. Config editor, session viewer, log tailing. |
-| `cli` | `packages/cli` | `nachos` CLI. `nachos init`, `nachos up`, `nachos config`. |
-| `shared` | `packages/shared` | Shared types, config schema, validation, utilities. |
-| `channels/discord` | `packages/channels/discord` | Discord adapter. |
-| `channels/slack` | `packages/channels/slack` | Slack adapter. |
-| `channels/telegram` | `packages/channels/telegram` | Telegram adapter. |
-| `channels/whatsapp` | `packages/channels/whatsapp` | WhatsApp adapter. |
-| `channels/matrix` | `packages/channels/matrix` | Matrix/Element adapter. |
-| `tools/filesystem` | `packages/tools/filesystem` | File read/write tool. |
-| `tools/web-fetch` | `packages/tools/web-fetch` | HTTP fetch / web scraping tool. |
-| `tools/code-runner` | `packages/tools/code-runner` | Sandboxed code execution. |
+| Package             | Path                         | Role                                                                       |
+| ------------------- | ---------------------------- | -------------------------------------------------------------------------- |
+| `gateway`           | `packages/core/gateway`      | Central orchestrator. Routes messages, manages sessions, dispatches tools. |
+| `bus`               | `packages/bus`               | Internal message bus. Channels and gateway communicate via events.         |
+| `llm-proxy`         | `packages/core/llm-proxy`    | Adapter layer for LLM providers (Anthropic, OpenAI, Bedrock, Ollama).      |
+| `admin`             | `packages/admin`             | Vue.js admin UI. Config editor, session viewer, log tailing.               |
+| `cli`               | `packages/cli`               | `nachos` CLI. `nachos init`, `nachos up`, `nachos config`.                 |
+| `shared`            | `packages/shared`            | Shared types, config schema, validation, utilities.                        |
+| `channels/discord`  | `packages/channels/discord`  | Discord adapter.                                                           |
+| `channels/slack`    | `packages/channels/slack`    | Slack adapter.                                                             |
+| `channels/telegram` | `packages/channels/telegram` | Telegram adapter.                                                          |
+| `channels/whatsapp` | `packages/channels/whatsapp` | WhatsApp adapter.                                                          |
+| `channels/matrix`   | `packages/channels/matrix`   | Matrix/Element adapter.                                                    |
+| `tools/filesystem`  | `packages/tools/filesystem`  | File read/write tool.                                                      |
+| `tools/web-fetch`   | `packages/tools/web-fetch`   | HTTP fetch / web scraping tool.                                            |
+| `tools/code-runner` | `packages/tools/code-runner` | Sandboxed code execution.                                                  |
 
 ---
 
@@ -70,14 +74,19 @@ Nachos is a monorepo of Docker-native packages that together form a self-hosted 
 The gateway is the brain. On message receipt:
 
 1. **Session lookup / creation** — each conversation gets a persistent session
-2. **Prompt assembly** — system prompt + tool definitions + message history assembled (see [BOOTSTRAP_PROMPT_ASSEMBLY.md](BOOTSTRAP_PROMPT_ASSEMBLY.md))
+2. **Prompt assembly** — system prompt + tool definitions + message history
+   assembled (see [BOOTSTRAP_PROMPT_ASSEMBLY.md](BOOTSTRAP_PROMPT_ASSEMBLY.md))
 3. **LLM dispatch** — request sent to configured LLM provider via llm-proxy
-4. **Tool handling** — if the LLM requests a tool call, gateway dispatches, collects result, re-enters LLM loop
-5. **Response delivery** — final response delivered back through the originating channel
+4. **Tool handling** — if the LLM requests a tool call, gateway dispatches,
+   collects result, re-enters LLM loop
+5. **Response delivery** — final response delivered back through the originating
+   channel
 
 ### Session Management
 
-Sessions are stored in StateStorage (SQLite by default, Postgres supported). Each session holds:
+Sessions are stored in StateStorage (SQLite by default, Postgres supported).
+Each session holds:
+
 - Conversation history (messages)
 - Session metadata (channel, user, status)
 - Configuration overrides
@@ -86,13 +95,16 @@ See `packages/core/gateway/src/session/` for implementation.
 
 ### Security Enforcement
 
-Security mode is applied at the gateway layer — before any tool is dispatched. See [Security Guide](security.md) and [ADR-002](adr/002-shell-tool-security-model.md).
+Security mode is applied at the gateway layer — before any tool is dispatched.
+See [Security Guide](security.md) and
+[ADR-002](adr/002-shell-tool-security-model.md).
 
 ---
 
 ## LLM Proxy
 
-The LLM proxy normalizes differences between providers into a single interface. All providers implement:
+The LLM proxy normalizes differences between providers into a single interface.
+All providers implement:
 
 ```typescript
 interface LLMProvider {
@@ -101,15 +113,19 @@ interface LLMProvider {
 }
 ```
 
-Provider selection is by `llm.provider` in config. See [ADR-001](adr/001-bedrock-adapter-type.md) for the Bedrock adapter decision.
+Provider selection is by `llm.provider` in config. See
+[ADR-001](adr/001-bedrock-adapter-type.md) for the Bedrock adapter decision.
 
 ---
 
 ## Message Bus
 
-The bus decouples channels from the gateway. Channels publish `message.received` events; the gateway subscribes and processes them. Responses are published back as `message.send` events.
+The bus decouples channels from the gateway. Channels publish `message.received`
+events; the gateway subscribes and processes them. Responses are published back
+as `message.send` events.
 
 This enables:
+
 - Hot-pluggable channels (add/remove without restarting gateway)
 - Future horizontal scaling (multiple gateway replicas)
 
@@ -117,21 +133,28 @@ This enables:
 
 ## Skills
 
-Skills are Markdown documents (`SKILL.md`) that provide the LLM with specialized knowledge for external tools and APIs. They are injected into the system prompt at startup.
+Skills are Markdown documents (`SKILL.md`) that provide the LLM with specialized
+knowledge for external tools and APIs. They are injected into the system prompt
+at startup.
 
-See [ADR-003](adr/003-skill-structure.md) for the skill format decision, and [SKILL_TOOLS.md](SKILL_TOOLS.md) for the catalog of available skills.
+See [ADR-003](adr/003-skill-structure.md) for the skill format decision, and
+[SKILL_TOOLS.md](SKILL_TOOLS.md) for the catalog of available skills.
 
 ---
 
 ## Configuration
 
-All configuration is in `nachos.toml`. Types are defined in `packages/shared/config/src/schema.ts` and validated at startup. See [Configuration Reference](configuration.md).
+All configuration is in `nachos.toml`. Types are defined in
+`packages/shared/config/src/schema.ts` and validated at startup. See
+[Configuration Reference](configuration.md).
 
 ---
 
 ## Further Reading
 
-- [Bootstrap Prompt Assembly](BOOTSTRAP_PROMPT_ASSEMBLY.md) — how the system prompt is constructed
-- [Subagent Orchestration](SUBAGENT_ORCHESTRATION.md) — how Nachos spawns and manages sub-agents
+- [Bootstrap Prompt Assembly](BOOTSTRAP_PROMPT_ASSEMBLY.md) — how the system
+  prompt is constructed
+- [Subagent Orchestration](SUBAGENT_ORCHESTRATION.md) — how Nachos spawns and
+  manages sub-agents
 - [ADRs](adr/) — all architectural decisions with rationale
 - [Guides](guides/) — deep dives on specific subsystems

--- a/docs/custom-modules.md
+++ b/docs/custom-modules.md
@@ -1,6 +1,7 @@
 # Creating Custom Modules
 
-Nachos is built to be extended. This guide covers adding your own channels, tools, and skills.
+Nachos is built to be extended. This guide covers adding your own channels,
+tools, and skills.
 
 ---
 
@@ -8,13 +9,14 @@ Nachos is built to be extended. This guide covers adding your own channels, tool
 
 There are three extension points:
 
-| Type | What It Does | Where It Lives |
-|---|---|---|
-| **Channel** | Connect Nachos to a messaging platform | `packages/channels/<name>/` |
-| **Tool** | Let Nachos take actions (run code, call APIs, etc.) | `packages/tools/<name>/` |
-| **Skill** | Give Nachos knowledge for an external service | `workspace/skills/<name>/SKILL.md` |
+| Type        | What It Does                                        | Where It Lives                     |
+| ----------- | --------------------------------------------------- | ---------------------------------- |
+| **Channel** | Connect Nachos to a messaging platform              | `packages/channels/<name>/`        |
+| **Tool**    | Let Nachos take actions (run code, call APIs, etc.) | `packages/tools/<name>/`           |
+| **Skill**   | Give Nachos knowledge for an external service       | `workspace/skills/<name>/SKILL.md` |
 
-Skills are the easiest — just a Markdown file, no code required. Channels and tools require TypeScript packages.
+Skills are the easiest — just a Markdown file, no code required. Channels and
+tools require TypeScript packages.
 
 ---
 
@@ -40,37 +42,33 @@ Brief description of what this skill enables.
 
 ## Authentication
 
-\`\`\`bash
-export MY_SERVICE_API_KEY="your-key-here"
-\`\`\`
+\`\`\`bash export MY_SERVICE_API_KEY="your-key-here" \`\`\`
 
 ## Common Operations
 
 ### List items
 
-\`\`\`bash
-curl -H "Authorization: Bearer $MY_SERVICE_API_KEY" \
-     https://api.myservice.com/v1/items
-\`\`\`
+\`\`\`bash curl -H "Authorization: Bearer $MY_SERVICE_API_KEY" \
+ https://api.myservice.com/v1/items \`\`\`
 
-Expected response:
-\`\`\`json
-{"items": [...], "total": 42}
-\`\`\`
+Expected response: \`\`\`json {"items": [...], "total": 42} \`\`\`
 
 ## Troubleshooting
 
-**401 Unauthorized** — Check your API key is set and valid.
-**404 Not Found** — The resource ID doesn't exist or you don't have access.
+**401 Unauthorized** — Check your API key is set and valid. **404 Not Found** —
+The resource ID doesn't exist or you don't have access.
 ```
 
-Skills are auto-discovered on next session start. See [SKILL_TOOLS.md](SKILL_TOOLS.md) for the full catalog and [ADR-003](adr/003-skill-structure.md) for format details.
+Skills are auto-discovered on next session start. See
+[SKILL_TOOLS.md](SKILL_TOOLS.md) for the full catalog and
+[ADR-003](adr/003-skill-structure.md) for format details.
 
 ---
 
 ## 2. Adding a Tool (Medium)
 
-Tools let Nachos take programmatic actions. They are TypeScript packages in `packages/tools/`.
+Tools let Nachos take programmatic actions. They are TypeScript packages in
+`packages/tools/`.
 
 ### Scaffold
 
@@ -81,6 +79,7 @@ cd packages/tools/my-tool
 ```
 
 Update `package.json`:
+
 ```json
 {
   "name": "@nachos/tool-my-tool",
@@ -92,7 +91,12 @@ Update `package.json`:
 
 ```typescript
 // src/index.ts
-import type { NachosTool, ToolDefinition, ToolContext, ToolResult } from '@nachos/shared';
+import type {
+  NachosTool,
+  ToolDefinition,
+  ToolContext,
+  ToolResult,
+} from '@nachos/shared';
 
 export class MyTool implements NachosTool {
   readonly name = 'my-tool';
@@ -150,7 +154,8 @@ type = "my-tool"
 
 ## 3. Adding a Channel (Advanced)
 
-Channels connect Nachos to messaging platforms. They publish and subscribe to the message bus.
+Channels connect Nachos to messaging platforms. They publish and subscribe to
+the message bus.
 
 ### Scaffold
 
@@ -163,7 +168,11 @@ cd packages/channels/my-channel
 
 ```typescript
 // src/index.ts
-import type { NachosChannel, InboundMessage, OutboundMessage } from '@nachos/shared';
+import type {
+  NachosChannel,
+  InboundMessage,
+  OutboundMessage,
+} from '@nachos/shared';
 
 export class MyChannel implements NachosChannel {
   readonly name = 'my-channel';
@@ -213,16 +222,24 @@ pnpm test
 
 ## Tips
 
-- **Start with a skill** — if you just need to call an API, a skill is almost always enough. Save tool/channel work for things that genuinely need programmatic integration.
-- **Look at existing packages** — `packages/tools/web-fetch` is a good minimal tool example; `packages/channels/discord` is the most complete channel example.
-- **Security**: Tools run with the security mode of the gateway. If your tool does sensitive operations, document it clearly and test with `strict` mode.
-- **Error handling**: Return descriptive errors from `execute()`. The LLM uses your error messages to self-correct.
+- **Start with a skill** — if you just need to call an API, a skill is almost
+  always enough. Save tool/channel work for things that genuinely need
+  programmatic integration.
+- **Look at existing packages** — `packages/tools/web-fetch` is a good minimal
+  tool example; `packages/channels/discord` is the most complete channel
+  example.
+- **Security**: Tools run with the security mode of the gateway. If your tool
+  does sensitive operations, document it clearly and test with `strict` mode.
+- **Error handling**: Return descriptive errors from `execute()`. The LLM uses
+  your error messages to self-correct.
 
 ---
 
 ## Further Reading
 
 - [SKILL_TOOLS.md](SKILL_TOOLS.md) — catalog of existing skills
-- [ADR-003: Skill Structure](adr/003-skill-structure.md) — skill format rationale
-- [Architecture Overview](architecture.md) — how channels, tools, and gateway connect
+- [ADR-003: Skill Structure](adr/003-skill-structure.md) — skill format
+  rationale
+- [Architecture Overview](architecture.md) — how channels, tools, and gateway
+  connect
 - [Security Guide](security.md) — security model and tool permissions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,12 +1,14 @@
 # Getting Started with Nachos
 
-Welcome to Nachos — your AI assistant, your way. This guide walks you from zero to a running instance in minutes.
+Welcome to Nachos — your AI assistant, your way. This guide walks you from zero
+to a running instance in minutes.
 
 ---
 
 ## Prerequisites
 
-- [Docker Desktop](https://docs.docker.com/get-docker/) (Mac/Windows) or Docker Engine + Compose plugin (Linux)
+- [Docker Desktop](https://docs.docker.com/get-docker/) (Mac/Windows) or Docker
+  Engine + Compose plugin (Linux)
 - An LLM API key (Anthropic, OpenAI, or a local Ollama instance)
 
 ---
@@ -26,7 +28,8 @@ cp .env.example .env
 docker compose up
 ```
 
-Open [http://localhost:8080](http://localhost:8080) to see the web chat interface.
+Open [http://localhost:8080](http://localhost:8080) to see the web chat
+interface.
 
 ---
 
@@ -60,13 +63,15 @@ type = "discord"
 token = "${DISCORD_TOKEN}"
 ```
 
-Set `DISCORD_TOKEN` in your `.env`. See [Skill Tools](SKILL_TOOLS.md) for available channel skills.
+Set `DISCORD_TOKEN` in your `.env`. See [Skill Tools](SKILL_TOOLS.md) for
+available channel skills.
 
 ---
 
 ## 4. Add Tools
 
-Tools let Nachos take actions (browse the web, run shell commands, read files). Example:
+Tools let Nachos take actions (browse the web, run shell commands, read files).
+Example:
 
 ```toml
 [[tools]]
@@ -97,21 +102,24 @@ docker compose -f docker-compose.dev.yml logs -f gateway
 
 - [Configuration Reference](configuration.md) — complete option reference
 - [Security Guide](security.md) — understand security modes and best practices
-- [Architecture Deep Dive](architecture.md) — how Nachos is structured internally
-- [Creating Custom Modules](custom-modules.md) — extend Nachos with your own channels and tools
+- [Architecture Deep Dive](architecture.md) — how Nachos is structured
+  internally
+- [Creating Custom Modules](custom-modules.md) — extend Nachos with your own
+  channels and tools
 - [ADRs](adr/) — architectural decisions and their rationale
 
 ---
 
 ## Troubleshooting
 
-**Container won't start:**
-Check that your `.env` has a valid API key and `nachos.toml` is present. Run `docker compose logs gateway` for details.
+**Container won't start:** Check that your `.env` has a valid API key and
+`nachos.toml` is present. Run `docker compose logs gateway` for details.
 
-**Web chat not loading:**
-Verify port 8080 is free. If using a custom port, check the `webui.port` config option.
+**Web chat not loading:** Verify port 8080 is free. If using a custom port,
+check the `webui.port` config option.
 
-**LLM errors / 401 Unauthorized:**
-Your API key is invalid or missing. Double-check `.env` and restart the stack.
+**LLM errors / 401 Unauthorized:** Your API key is invalid or missing.
+Double-check `.env` and restart the stack.
 
-For more help, see the [full troubleshooting guide](TROUBLESHOOTING.md) (coming soon) or open a GitHub issue.
+For more help, see the [full troubleshooting guide](TROUBLESHOOTING.md) (coming
+soon) or open a GitHub issue.

--- a/docs/onboarding-customization.md
+++ b/docs/onboarding-customization.md
@@ -1,19 +1,28 @@
 # Onboarding Customization
 
-Nachos includes a built-in first-run onboarding flow that guides new users through setting up their assistant's identity, persona, and preferences. This guide explains how to customize or replace that flow.
+Nachos includes a built-in first-run onboarding flow that guides new users
+through setting up their assistant's identity, persona, and preferences. This
+guide explains how to customize or replace that flow.
 
 ## How the default onboarding works
 
-On first boot, Nachos checks whether identity setup has been completed. If not, it injects a `BOOTSTRAP` block into the system prompt that instructs the LLM to run an interactive onboarding conversation.
+On first boot, Nachos checks whether identity setup has been completed. If not,
+it injects a `BOOTSTRAP` block into the system prompt that instructs the LLM to
+run an interactive onboarding conversation.
 
 The default flow asks the user four questions, one at a time:
 
 1. **What should I call myself?** — Sets the assistant name and persona/vibe
-2. **Who am I talking to?** — Sets the user's name, preferred address, and timezone
-3. **What are my core values?** — Sets the soul (working style, tone, privacy preferences)
-4. **Any tools or credentials to note?** — Seeds the TOOLS block with local context
+2. **Who am I talking to?** — Sets the user's name, preferred address, and
+   timezone
+3. **What are my core values?** — Sets the soul (working style, tone, privacy
+   preferences)
+4. **Any tools or credentials to note?** — Seeds the TOOLS block with local
+   context
 
-When the user is done, the LLM calls `bootstrap(action: set, identityCompleted: true)` which saves all blocks and clears the bootstrap flow for future sessions.
+When the user is done, the LLM calls
+`bootstrap(action: set, identityCompleted: true)` which saves all blocks and
+clears the bootstrap flow for future sessions.
 
 ---
 
@@ -45,7 +54,8 @@ Store your onboarding prompt in a separate file for easier editing:
 bootstrap_prompt = "./my-bootstrap.md"
 ```
 
-The path is resolved relative to your `nachos.toml` file. Absolute paths are also accepted.
+The path is resolved relative to your `nachos.toml` file. Absolute paths are
+also accepted.
 
 **Example `my-bootstrap.md`:**
 
@@ -63,9 +73,13 @@ When done, call bootstrap(action: set, identityCompleted: true).
 
 ### Option 3: Skip interactive onboarding (ops/team deployments)
 
-For automated deployments where you don't want interactive setup, write the identity, soul, user, and tools blocks directly into your state store at provisioning time and mark `identityCompleted: true`. This skips the onboarding conversation entirely.
+For automated deployments where you don't want interactive setup, write the
+identity, soul, user, and tools blocks directly into your state store at
+provisioning time and mark `identityCompleted: true`. This skips the onboarding
+conversation entirely.
 
 This is the recommended approach for:
+
 - Docker deployments with pre-configured personas
 - Team environments where the assistant configuration is managed centrally
 - CI/CD pipelines spinning up short-lived instances
@@ -74,9 +88,12 @@ This is the recommended approach for:
 
 ## What the custom prompt should do
 
-If you provide a custom bootstrap prompt, it replaces only the `BOOTSTRAP` block in the system prompt. The other blocks (AGENTS, SOUL, IDENTITY, USER, TOOLS) retain their default placeholder values.
+If you provide a custom bootstrap prompt, it replaces only the `BOOTSTRAP` block
+in the system prompt. The other blocks (AGENTS, SOUL, IDENTITY, USER, TOOLS)
+retain their default placeholder values.
 
 Your custom prompt **must** instruct the LLM to:
+
 1. Collect the information it needs from the user
 2. Call `bootstrap(action: set, identityCompleted: true)` when setup is complete
 
@@ -93,14 +110,16 @@ When you have enough to proceed, call bootstrap(action: set, identityCompleted: 
 
 ## Default bootstrap block reference
 
-If you want to modify the default rather than replace it, here's what the default block guides the LLM to do:
+If you want to modify the default rather than replace it, here's what the
+default block guides the LLM to do:
 
 - Greet the user and explain the setup flow
 - Step 1: Ask for the assistant's name and persona/vibe → fills IDENTITY
 - Step 2: Ask for the user's name, address, and timezone → fills USER
 - Step 3: Ask for working style and tone preferences → fills SOUL
 - Step 4: Ask for tools, credentials, or local conventions → fills TOOLS
-- Complete: Call `bootstrap(action: set, identityCompleted: true)` with all blocks populated
+- Complete: Call `bootstrap(action: set, identityCompleted: true)` with all
+  blocks populated
 
 ---
 

--- a/docs/onboarding-customization.md
+++ b/docs/onboarding-customization.md
@@ -1,0 +1,124 @@
+# Onboarding Customization
+
+Nachos includes a built-in first-run onboarding flow that guides new users through setting up their assistant's identity, persona, and preferences. This guide explains how to customize or replace that flow.
+
+## How the default onboarding works
+
+On first boot, Nachos checks whether identity setup has been completed. If not, it injects a `BOOTSTRAP` block into the system prompt that instructs the LLM to run an interactive onboarding conversation.
+
+The default flow asks the user four questions, one at a time:
+
+1. **What should I call myself?** — Sets the assistant name and persona/vibe
+2. **Who am I talking to?** — Sets the user's name, preferred address, and timezone
+3. **What are my core values?** — Sets the soul (working style, tone, privacy preferences)
+4. **Any tools or credentials to note?** — Seeds the TOOLS block with local context
+
+When the user is done, the LLM calls `bootstrap(action: set, identityCompleted: true)` which saves all blocks and clears the bootstrap flow for future sessions.
+
+---
+
+## Customizing the onboarding prompt
+
+### Option 1: Inline prompt in nachos.toml
+
+Provide the full onboarding instructions directly in your config:
+
+```toml
+[assistant]
+bootstrap_prompt = """
+Welcome! I'm your new assistant. Let's get set up quickly.
+
+What would you like to name me, and what should I call you?
+After you tell me, I'll ask one more question about your preferences,
+then we'll be ready to go.
+
+When setup is complete, call bootstrap(action: set, identityCompleted: true).
+"""
+```
+
+### Option 2: File path in nachos.toml
+
+Store your onboarding prompt in a separate file for easier editing:
+
+```toml
+[assistant]
+bootstrap_prompt = "./my-bootstrap.md"
+```
+
+The path is resolved relative to your `nachos.toml` file. Absolute paths are also accepted.
+
+**Example `my-bootstrap.md`:**
+
+```markdown
+Welcome to AcmeCorp Assistant! I'm here to help your team.
+
+Let's get set up. I'll ask a few quick questions:
+
+1. What's your name and what should I call you?
+2. What team are you on? (Engineering, Product, etc.)
+3. Any tools or systems I should know about?
+
+When done, call bootstrap(action: set, identityCompleted: true).
+```
+
+### Option 3: Skip interactive onboarding (ops/team deployments)
+
+For automated deployments where you don't want interactive setup, write the identity, soul, user, and tools blocks directly into your state store at provisioning time and mark `identityCompleted: true`. This skips the onboarding conversation entirely.
+
+This is the recommended approach for:
+- Docker deployments with pre-configured personas
+- Team environments where the assistant configuration is managed centrally
+- CI/CD pipelines spinning up short-lived instances
+
+---
+
+## What the custom prompt should do
+
+If you provide a custom bootstrap prompt, it replaces only the `BOOTSTRAP` block in the system prompt. The other blocks (AGENTS, SOUL, IDENTITY, USER, TOOLS) retain their default placeholder values.
+
+Your custom prompt **must** instruct the LLM to:
+1. Collect the information it needs from the user
+2. Call `bootstrap(action: set, identityCompleted: true)` when setup is complete
+
+The `bootstrap` tool call saves all block values and clears the bootstrap flow.
+
+**Minimum viable custom prompt:**
+
+```
+Ask the user their name and how they want the assistant to behave.
+When you have enough to proceed, call bootstrap(action: set, identityCompleted: true).
+```
+
+---
+
+## Default bootstrap block reference
+
+If you want to modify the default rather than replace it, here's what the default block guides the LLM to do:
+
+- Greet the user and explain the setup flow
+- Step 1: Ask for the assistant's name and persona/vibe → fills IDENTITY
+- Step 2: Ask for the user's name, address, and timezone → fills USER
+- Step 3: Ask for working style and tone preferences → fills SOUL
+- Step 4: Ask for tools, credentials, or local conventions → fills TOOLS
+- Complete: Call `bootstrap(action: set, identityCompleted: true)` with all blocks populated
+
+---
+
+## Nachos.toml example
+
+```toml
+[nachos]
+name = "AcmeCorp Assistant"
+version = "1.0"
+
+[llm]
+provider = "anthropic"
+model = "claude-sonnet-4-6"
+
+[assistant]
+name = "Acme Bot"
+bootstrap_prompt = "./onboarding/acme-bootstrap.md"
+
+[security]
+mode = "standard"
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,7 @@
 # Security Guide
 
-Nachos is designed with security-first defaults. This guide explains the security model, available modes, and best practices for safe deployment.
+Nachos is designed with security-first defaults. This guide explains the
+security model, available modes, and best practices for safe deployment.
 
 ---
 
@@ -9,17 +10,20 @@ Nachos is designed with security-first defaults. This guide explains the securit
 Nachos has three security modes, set via `security.mode` in `nachos.toml`:
 
 ### `strict` (default)
+
 - Only allowlisted tools enabled
 - No shell access
 - Pairing required for DMs
 - Recommended for production
 
 ### `standard`
+
 - Common tools enabled (file inspection, network debugging, git read)
 - Pairing-based DMs
 - Balanced security for trusted environments
 
 ### `permissive`
+
 - All tools available, including shell
 - Use only in air-gapped or fully trusted environments
 
@@ -32,17 +36,21 @@ mode = "standard"  # strict | standard | permissive
 
 ## Shell Tool Security
 
-When the shell tool is enabled (`mode = "permissive"` or explicit config), Nachos enforces:
+When the shell tool is enabled (`mode = "permissive"` or explicit config),
+Nachos enforces:
 
 1. **Binary allowlist** — only registered binaries can be executed
-2. **Direct process spawning** — no shell interpreter, eliminating injection attacks
+2. **Direct process spawning** — no shell interpreter, eliminating injection
+   attacks
 3. **Subcommand filtering** — e.g., `git status` is allowed, `git push` is not
 4. **Resource limits** — 30s timeout (configurable, max 5min), 100KB output cap
-5. **Audit logging** — all executions logged to `/var/log/nachos/shell-audit.log`
+5. **Audit logging** — all executions logged to
+   `/var/log/nachos/shell-audit.log`
 
 See [ADR-002](adr/002-shell-tool-security-model.md) for the full rationale.
 
 **What's blocked by default:**
+
 - Destructive ops: `rm`, `mv`, `chmod`, `chown`
 - Shell execution: `bash`, `sh`, `eval`
 - Package managers: `npm install`, `apt-get`, `pip`
@@ -52,23 +60,28 @@ See [ADR-002](adr/002-shell-tool-security-model.md) for the full rationale.
 
 ## Network Isolation
 
-Nachos runs in an isolated Docker network by default. Containers cannot reach each other unless explicitly linked. The gateway is the only externally-exposed service.
+Nachos runs in an isolated Docker network by default. Containers cannot reach
+each other unless explicitly linked. The gateway is the only externally-exposed
+service.
 
 ```yaml
 # docker-compose.yml (enforced)
 networks:
   nachos-internal:
-    internal: true  # no external routing
+    internal: true # no external routing
 ```
 
-To allow outbound access (e.g., for web browsing tools), set `security.mode = "standard"` or add explicit network policies.
+To allow outbound access (e.g., for web browsing tools), set
+`security.mode = "standard"` or add explicit network policies.
 
 ---
 
 ## Credential Handling
 
 **Rules:**
-- Never put API keys or tokens in `nachos.toml`. Use `.env` or environment variables.
+
+- Never put API keys or tokens in `nachos.toml`. Use `.env` or environment
+  variables.
 - `.env` is in `.gitignore` — do not commit it.
 - Tokens referenced as `${ENV_VAR}` in config are resolved at startup.
 
@@ -88,7 +101,8 @@ token = "MTAzN..."  # Never do this
 
 ## Pairing and DMs
 
-Direct Messages to the bot are gated by the pairing system. A user must complete a pairing handshake before they can send private messages.
+Direct Messages to the bot are gated by the pairing system. A user must complete
+a pairing handshake before they can send private messages.
 
 - `security.mode = "strict"`: Pairing always required for DMs
 - `security.mode = "standard"`: Pairing required for DMs (same)
@@ -100,11 +114,11 @@ Direct Messages to the bot are gated by the pairing system. A user must complete
 
 All tool executions and config changes are logged. Log locations:
 
-| Event | Log path |
-|---|---|
-| Shell commands | `/var/log/nachos/shell-audit.log` |
+| Event          | Log path                                    |
+| -------------- | ------------------------------------------- |
+| Shell commands | `/var/log/nachos/shell-audit.log`           |
 | Gateway events | Docker logs (`docker compose logs gateway`) |
-| Config loads | Gateway startup logs |
+| Config loads   | Gateway startup logs                        |
 
 ---
 
@@ -121,7 +135,8 @@ All tool executions and config changes are logged. Log locations:
 
 ## Reporting Vulnerabilities
 
-Please do not open public GitHub issues for security vulnerabilities. Email the maintainers directly or use GitHub's private security advisory feature.
+Please do not open public GitHub issues for security vulnerabilities. Email the
+maintainers directly or use GitHub's private security advisory feature.
 
 ---
 

--- a/packages/core/gateway/src/main.ts
+++ b/packages/core/gateway/src/main.ts
@@ -15,9 +15,10 @@ import {
 } from './index.js';
 import { NatsBusAdapter } from './router.js';
 import type { StateLayerConfig } from '@nachos/state';
-import type { ContextManagementCommandsConfig, RuntimeConfig } from '@nachos/config';
+import type { ContextManagementCommandsConfig, RuntimeConfig, NachosConfig } from '@nachos/config';
 import path from 'node:path';
 import { patternCategories, patterns as dlpPatterns } from '@nacho-labs/nachos-dlp';
+import { readFileSync } from 'node:fs';
 
 async function buildDlpConfig(configPath?: string): Promise<DLPConfig | undefined> {
   const nachosConfig = loadAndValidateConfig({ configPath });
@@ -86,7 +87,7 @@ async function start(): Promise<void> {
       })
     : undefined;
 
-  const stateLayerConfig = buildStateLayerConfig(runtime);
+  const stateLayerConfig = buildStateLayerConfig(runtime, nachosConfig, configPath);
   const memoryPipelineConfig = proactiveHistory?.enabled
     ? {
         proactiveHistory,
@@ -331,7 +332,48 @@ function mapContextManagement(config: RuntimeConfig['context_management']) {
   };
 }
 
-function buildStateLayerConfig(runtime?: RuntimeConfig): StateLayerConfig {
+function resolveBootstrapPrompt(
+  bootstrapPromptConfig: string | undefined,
+  configPath: string | undefined
+): string | undefined {
+  if (!bootstrapPromptConfig) return undefined;
+
+  // If it looks like a file path, try to read it
+  const looksLikePath =
+    bootstrapPromptConfig.startsWith('./') ||
+    bootstrapPromptConfig.startsWith('../') ||
+    bootstrapPromptConfig.startsWith('/') ||
+    bootstrapPromptConfig.endsWith('.md') ||
+    bootstrapPromptConfig.endsWith('.txt');
+
+  if (looksLikePath) {
+    try {
+      let resolvedPath: string;
+      if (path.isAbsolute(bootstrapPromptConfig)) {
+        resolvedPath = bootstrapPromptConfig;
+      } else {
+        // Resolve relative to nachos.toml location
+        const configDir = configPath ? path.dirname(path.resolve(configPath)) : process.cwd();
+        resolvedPath = path.resolve(configDir, bootstrapPromptConfig);
+      }
+      return readFileSync(resolvedPath, 'utf-8');
+    } catch (err) {
+      logger.warn(
+        { path: bootstrapPromptConfig, err },
+        'assistant.bootstrap_prompt file not found, falling back to inline string'
+      );
+      // Fall through to return as-is
+    }
+  }
+
+  return bootstrapPromptConfig;
+}
+
+function buildStateLayerConfig(
+  runtime?: RuntimeConfig,
+  nachosConfig?: NachosConfig,
+  configPath?: string
+): StateLayerConfig {
   const stateDir = runtime?.state_dir ?? './state';
   const identityProvider = runtime?.state?.identity?.provider ?? 'filesystem';
   const memoryProvider = runtime?.state?.memory?.provider ?? 'filesystem';
@@ -415,6 +457,10 @@ function buildStateLayerConfig(runtime?: RuntimeConfig): StateLayerConfig {
       maxMemoryFacts: runtime?.state?.prompt_report?.max_memory_facts ?? 50,
       includeSessionState: runtime?.state?.prompt_report?.include_session_state ?? false,
     },
+    customBootstrapPrompt: resolveBootstrapPrompt(
+      nachosConfig?.assistant?.bootstrap_prompt,
+      configPath
+    ),
   };
 }
 

--- a/packages/shared/config/src/schema.ts
+++ b/packages/shared/config/src/schema.ts
@@ -729,6 +729,20 @@ export interface RuntimeConfig {
 export interface AssistantConfig {
   name?: string;
   system_prompt?: string;
+  /**
+   * Custom bootstrap prompt for the first-run onboarding conversation.
+   *
+   * Accepts either:
+   * - A file path (relative to nachos.toml, or absolute): `"./my-bootstrap.md"` or `"/etc/nachos/bootstrap.md"`
+   * - An inline string with the prompt content directly
+   *
+   * When provided, this replaces the default structured onboarding conversation.
+   * All other bootstrap blocks (AGENTS, SOUL, IDENTITY, USER, TOOLS) retain their defaults.
+   *
+   * @example File path: bootstrap_prompt = "./my-onboarding.md"
+   * @example Inline: bootstrap_prompt = "Welcome! Tell me your name and I'll get started."
+   */
+  bootstrap_prompt?: string;
 }
 
 /**

--- a/packages/shared/config/src/validation.test.ts
+++ b/packages/shared/config/src/validation.test.ts
@@ -359,7 +359,9 @@ describe('Configuration Validation', () => {
 
       const result = validateConfig(config);
       expect(result.valid).toBe(false);
-      expect(result.errors.some((e) => e.includes('Unknown config key: assistant.unknown_key'))).toBe(true);
+      expect(
+        result.errors.some((e) => e.includes('Unknown config key: assistant.unknown_key'))
+      ).toBe(true);
     });
 
     it('should reject llm.providers as unknown key', () => {

--- a/packages/shared/config/src/validation.test.ts
+++ b/packages/shared/config/src/validation.test.ts
@@ -320,6 +320,48 @@ describe('Configuration Validation', () => {
       expect(result.valid).toBe(true);
     });
 
+    it('should accept assistant config with bootstrap_prompt as inline string', () => {
+      const config: NachosConfig = {
+        nachos: { name: 'test', version: '1.0' },
+        llm: { provider: 'anthropic', model: 'claude' },
+        security: { mode: 'standard' },
+        assistant: {
+          name: 'Nacho',
+          bootstrap_prompt: 'Welcome! Tell me your name and I will get started.',
+        },
+      };
+
+      const result = validateConfig(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should accept assistant config with bootstrap_prompt as file path', () => {
+      const config: NachosConfig = {
+        nachos: { name: 'test', version: '1.0' },
+        llm: { provider: 'anthropic', model: 'claude' },
+        security: { mode: 'standard' },
+        assistant: { bootstrap_prompt: './my-onboarding.md' },
+      };
+
+      const result = validateConfig(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should reject unknown keys alongside bootstrap_prompt', () => {
+      const config = {
+        nachos: { name: 'test', version: '1.0' },
+        llm: { provider: 'anthropic', model: 'claude' },
+        security: { mode: 'standard' },
+        assistant: { bootstrap_prompt: 'Hello!', unknown_key: 'oops' },
+      } as unknown as NachosConfig;
+
+      const result = validateConfig(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Unknown config key: assistant.unknown_key'))).toBe(true);
+    });
+
     it('should reject llm.providers as unknown key', () => {
       const config = {
         nachos: { name: 'test', version: '1.0' },

--- a/packages/shared/config/src/validation.ts
+++ b/packages/shared/config/src/validation.ts
@@ -411,7 +411,7 @@ const CONFIG_SHAPE: SchemaNode = {
       network: true,
     },
   },
-  assistant: { name: true, system_prompt: true },
+  assistant: { name: true, system_prompt: true, bootstrap_prompt: true },
   skills: {
     enabled: true,
     allow: true,

--- a/packages/shared/state/src/bootstrap/bootstrap-templates.test.ts
+++ b/packages/shared/state/src/bootstrap/bootstrap-templates.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createDefaultBootstrapBlocks,
+  createBootstrapBlocksWithCustomPrompt,
+} from './bootstrap-templates.js';
+
+describe('createDefaultBootstrapBlocks', () => {
+  it('should return all expected block keys', () => {
+    const blocks = createDefaultBootstrapBlocks();
+    expect(blocks).toHaveProperty('agents');
+    expect(blocks).toHaveProperty('soul');
+    expect(blocks).toHaveProperty('tools');
+    expect(blocks).toHaveProperty('identity');
+    expect(blocks).toHaveProperty('user');
+    expect(blocks).toHaveProperty('bootstrap');
+  });
+
+  it('should have a non-empty bootstrap block', () => {
+    const blocks = createDefaultBootstrapBlocks();
+    expect(blocks.bootstrap).toBeTruthy();
+    expect(blocks.bootstrap.length).toBeGreaterThan(10);
+  });
+
+  it('bootstrap block should guide structured onboarding', () => {
+    const blocks = createDefaultBootstrapBlocks();
+    // Should guide name collection
+    expect(blocks.bootstrap).toContain('name');
+    // Should guide identity setup
+    expect(blocks.bootstrap).toContain('IDENTITY');
+    // Should guide user profile
+    expect(blocks.bootstrap).toContain('USER');
+    // Should instruct to complete bootstrap
+    expect(blocks.bootstrap).toContain('bootstrap');
+    expect(blocks.bootstrap).toContain('identityCompleted');
+  });
+
+  it('identity block should have blank fields for user to fill in', () => {
+    const blocks = createDefaultBootstrapBlocks();
+    expect(blocks.identity).toContain('Name:');
+    expect(blocks.identity).toContain('Role or vibe:');
+  });
+
+  it('user block should have blank fields for user to fill in', () => {
+    const blocks = createDefaultBootstrapBlocks();
+    expect(blocks.user).toContain('Name:');
+    expect(blocks.user).toContain('Timezone:');
+  });
+});
+
+describe('createBootstrapBlocksWithCustomPrompt', () => {
+  it('should replace the bootstrap block with custom content', () => {
+    const customPrompt = 'Welcome to MyBot! Tell me your name.';
+    const blocks = createBootstrapBlocksWithCustomPrompt(customPrompt);
+    expect(blocks.bootstrap).toBe(customPrompt);
+  });
+
+  it('should retain all other default blocks unchanged', () => {
+    const defaults = createDefaultBootstrapBlocks();
+    const customPrompt = 'Custom onboarding flow';
+    const blocks = createBootstrapBlocksWithCustomPrompt(customPrompt);
+
+    expect(blocks.agents).toBe(defaults.agents);
+    expect(blocks.soul).toBe(defaults.soul);
+    expect(blocks.tools).toBe(defaults.tools);
+    expect(blocks.identity).toBe(defaults.identity);
+    expect(blocks.user).toBe(defaults.user);
+  });
+
+  it('should handle empty string custom prompt', () => {
+    const blocks = createBootstrapBlocksWithCustomPrompt('');
+    expect(blocks.bootstrap).toBe('');
+  });
+
+  it('should handle multiline custom prompts', () => {
+    const customPrompt = 'Line one\nLine two\nLine three';
+    const blocks = createBootstrapBlocksWithCustomPrompt(customPrompt);
+    expect(blocks.bootstrap).toBe(customPrompt);
+  });
+});

--- a/packages/shared/state/src/bootstrap/bootstrap-templates.ts
+++ b/packages/shared/state/src/bootstrap/bootstrap-templates.ts
@@ -36,10 +36,39 @@ export function createDefaultBootstrapBlocks(): BootstrapBlockMap {
     bootstrap: [
       'BOOTSTRAP',
       '',
-      'This is the first-run setup.',
-      'Ask the user to fill in IDENTITY and USER details, then SOUL.',
-      'When done, call the bootstrap tool with identityCompleted=true.',
-      'This will auto-clear the bootstrap block.',
+      "Welcome! I'm your new assistant. Let's get set up — this will only take a minute.",
+      '',
+      "I'll ask you a few questions one at a time. Take your time.",
+      '',
+      '**Step 1 — What should I call myself?**',
+      'Ask: "What would you like to name me? You can also give me a short description of my role or vibe (e.g. \"sharp and direct\", \"friendly and curious\")."',
+      '',
+      '**Step 2 — Who am I talking to?**',
+      'Ask: "What\'s your name, and what should I call you? (Optional: timezone, any preferences I should know about)"',
+      '',
+      '**Step 3 — What are my core values?**',
+      'Ask: "How should I behave? A sentence or two is fine — things like tone, privacy preferences, or what you want me to prioritize."',
+      '',
+      '**Step 4 — Any tools or credentials to note?**',
+      'Ask: "Are there any tools, accounts, or local conventions I should know about? (You can always update this later — just say \'skip\' to move on.)"',
+      '',
+      'After collecting all answers, write everything into the IDENTITY, USER, SOUL, and TOOLS blocks',
+      'using a single bootstrap(action: set, identityCompleted: true) call.',
+      '',
+      'Keep the conversation warm and brief. One question at a time. Skip steps the user already answered.',
+      'When the user says they are done or you have enough to proceed, complete setup.',
     ].join('\n'),
+  };
+}
+
+/**
+ * Build a BootstrapBlockMap using a custom bootstrap prompt to replace the default onboarding block.
+ * All other blocks (AGENTS, SOUL, IDENTITY, USER, TOOLS) retain their defaults.
+ */
+export function createBootstrapBlocksWithCustomPrompt(customPrompt: string): BootstrapBlockMap {
+  const defaults = createDefaultBootstrapBlocks();
+  return {
+    ...defaults,
+    bootstrap: customPrompt,
   };
 }

--- a/packages/shared/state/src/bootstrap/bootstrap-templates.ts
+++ b/packages/shared/state/src/bootstrap/bootstrap-templates.ts
@@ -41,7 +41,7 @@ export function createDefaultBootstrapBlocks(): BootstrapBlockMap {
       "I'll ask you a few questions one at a time. Take your time.",
       '',
       '**Step 1 — What should I call myself?**',
-      'Ask: "What would you like to name me? You can also give me a short description of my role or vibe (e.g. \"sharp and direct\", \"friendly and curious\")."',
+      'Ask: "What would you like to name me? You can also give me a short description of my role or vibe (e.g. "sharp and direct", "friendly and curious")."',
       '',
       '**Step 2 — Who am I talking to?**',
       'Ask: "What\'s your name, and what should I call you? (Optional: timezone, any preferences I should know about)"',

--- a/packages/shared/state/src/state-layer.ts
+++ b/packages/shared/state/src/state-layer.ts
@@ -35,7 +35,10 @@ import { FilesystemIdentityStore } from './identity/filesystem-identity-store.js
 import { PostgresIdentityStore } from './identity/postgres-identity-store.js';
 import { FilesystemBootstrapStore } from './bootstrap/filesystem-bootstrap-store.js';
 import { PostgresBootstrapStore } from './bootstrap/postgres-bootstrap-store.js';
-import { createDefaultBootstrapBlocks } from './bootstrap/bootstrap-templates.js';
+import {
+  createDefaultBootstrapBlocks,
+  createBootstrapBlocksWithCustomPrompt,
+} from './bootstrap/bootstrap-templates.js';
 import { sanitizeBootstrapContent } from './bootstrap/sanitizer.js';
 import { FilesystemMemoryStore } from './memory/filesystem-memory-store.js';
 import { PostgresMemoryStore } from './memory/postgres-memory-store.js';
@@ -79,6 +82,7 @@ export class StateLayer {
   private promptAssembler: PromptAssembler;
   private dependencies: StateLayerDependencies;
   private pgPools: Pool[];
+  private customBootstrapPrompt?: string;
 
   constructor(params: {
     identityStore: IdentityStore;
@@ -91,6 +95,7 @@ export class StateLayer {
     promptAssembler: PromptAssembler;
     dependencies?: StateLayerDependencies;
     pgPools?: Pool[];
+    customBootstrapPrompt?: string;
   }) {
     this.identityStore = params.identityStore;
     this.bootstrapStore = params.bootstrapStore;
@@ -102,6 +107,7 @@ export class StateLayer {
     this.promptAssembler = params.promptAssembler;
     this.dependencies = params.dependencies ?? {};
     this.pgPools = params.pgPools ?? [];
+    this.customBootstrapPrompt = params.customBootstrapPrompt;
 
     if (!this.dependencies.policyCheck) {
       logger.warn(
@@ -273,12 +279,16 @@ export class StateLayer {
         return existing;
       }
 
+      const content = this.customBootstrapPrompt
+        ? createBootstrapBlocksWithCustomPrompt(this.customBootstrapPrompt)
+        : createDefaultBootstrapBlocks();
+
       const profile: BootstrapProfile = {
         agentId,
-        content: createDefaultBootstrapBlocks(),
+        content,
         updatedAt: new Date().toISOString(),
         version: 1,
-        source: 'default',
+        source: this.customBootstrapPrompt ? 'config' : 'default',
       };
 
       await this.ensureAllowed('state.bootstrap.write', context, agentId);
@@ -607,6 +617,7 @@ export function createStateLayer(
     promptAssembler,
     dependencies: deps,
     pgPools,
+    customBootstrapPrompt: config.customBootstrapPrompt,
   });
 }
 

--- a/packages/shared/state/src/types.ts
+++ b/packages/shared/state/src/types.ts
@@ -81,6 +81,12 @@ export interface StateLayerConfig {
   sessions?: SessionsStoreConfig;
   workspace?: WorkspaceDocumentStoreConfig;
   prompt?: PromptAssemblyConfig;
+  /**
+   * Custom bootstrap prompt content (resolved string, not a file path).
+   * When set, replaces the default onboarding conversation block.
+   * File path resolution from nachos.toml is done at the Gateway/main level before passing here.
+   */
+  customBootstrapPrompt?: string;
 }
 
 export interface StatePolicyRequest {

--- a/packages/shared/types/src/state-types.ts
+++ b/packages/shared/types/src/state-types.ts
@@ -2,7 +2,7 @@
  * State layer types for identity, memory, session state, and prompt reporting.
  */
 
-export type IdentitySource = 'filesystem' | 'db' | 'api' | 'unknown' | 'default';
+export type IdentitySource = 'filesystem' | 'db' | 'api' | 'unknown' | 'default' | 'config';
 
 export type BootstrapBlockMap = Record<string, string>;
 


### PR DESCRIPTION
Closes #194

## Summary

Two features shipped together:

### 1. Improved default bootstrap onboarding
The previous default bootstrap block was 4 sparse lines that left too much to LLM improvisation. The new default guides a complete structured onboarding conversation, one question at a time:

- Step 1: Assistant name + persona/vibe → writes IDENTITY block
- Step 2: User name, address, timezone → writes USER block
- Step 3: Working style and tone preferences → writes SOUL block
- Step 4: Tools, credentials, local conventions → writes TOOLS block
- Completes with a single `bootstrap(action: set, identityCompleted: true)` call

### 2. `nachos.toml` `assistant.bootstrap_prompt` config
Power users can now replace the default onboarding with their own prompt, either inline or via file path:

```toml
[assistant]
# Inline string
bootstrap_prompt = "Welcome! Tell me your name and I'll get started."

# Or file path (resolved relative to nachos.toml)
bootstrap_prompt = "./my-onboarding.md"
```

File-path-style values (starting with `./`, `../`, `/`, or ending in `.md`/`.txt`) are read from disk at startup. Relative paths resolve against the `nachos.toml` location. Falls back to the value as an inline string if the file isn't found.

All other blocks (AGENTS, SOUL, IDENTITY, USER, TOOLS) retain their defaults when a custom prompt is provided.

## Files changed

| File | Change |
|---|---|
| `packages/shared/state/src/bootstrap/bootstrap-templates.ts` | Improved default bootstrap block; added `createBootstrapBlocksWithCustomPrompt()` |
| `packages/shared/state/src/bootstrap/bootstrap-templates.test.ts` | 9 new unit tests |
| `packages/shared/state/src/state-layer.ts` | Uses custom prompt in `seedBootstrapProfile()` |
| `packages/shared/state/src/types.ts` | Added `customBootstrapPrompt` to `StateLayerConfig` |
| `packages/shared/types/src/state-types.ts` | Added `'config'` to `IdentitySource` union |
| `packages/shared/config/src/schema.ts` | Added `bootstrap_prompt` to `AssistantConfig` |
| `packages/shared/config/src/validation.ts` | Added `bootstrap_prompt` to `CONFIG_SHAPE` |
| `packages/shared/config/src/validation.test.ts` | 3 new config validation tests |
| `packages/core/gateway/src/main.ts` | `resolveBootstrapPrompt()` + wired into `buildStateLayerConfig()` |
| `docs/onboarding-customization.md` | New guide covering all three usage patterns |

## Tests

- 103 total tests pass (config + state bootstrap suites)
- 12 net new tests covering the new functionality
- All pre-existing tests unchanged

## Acceptance criteria

- [x] Default bootstrap block guides a complete, structured onboarding conversation
- [x] `nachos.toml` accepts `assistant.bootstrap_prompt` (file path or inline string)  
- [x] Custom prompt is used instead of default when provided
- [x] Unit tests for config parsing + seeding
- [x] Docs: onboarding customization guide
- [ ] (Stretch) `assistant.soul` / `assistant.identity` / `assistant.user_profile` auto-seed — left for follow-up